### PR TITLE
fix(tabs): prevent trigger form submission

### DIFF
--- a/packages/react/components/Tabs/Component.tsx
+++ b/packages/react/components/Tabs/Component.tsx
@@ -54,14 +54,14 @@ const [TabTriggerVariant, resolveTabTriggerVariantProps] = vcn({
 
 interface TabTriggerProps
   extends Omit<VariantProps<typeof TabTriggerVariant>, "active">,
-    React.HTMLAttributes<HTMLButtonElement>,
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "name">,
     Tab,
     AsChild {}
 
 const TabTrigger = (props: TabTriggerProps) => {
   const [variantProps, restPropsBeforeParse] =
     resolveTabTriggerVariantProps(props);
-  const { name, ...restProps } = restPropsBeforeParse;
+  const { asChild, name, type, ...restProps } = restPropsBeforeParse;
   const [context, setContext] = React.useContext(TabContext);
 
   React.useEffect(() => {
@@ -83,7 +83,7 @@ const TabTrigger = (props: TabTriggerProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, setContext]);
 
-  const Comp = props.asChild ? Slot : "button";
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -91,6 +91,7 @@ const TabTrigger = (props: TabTriggerProps) => {
         ...variantProps,
         active: context.active[1] === name,
       })}
+      type={asChild ? type : type ?? "button"}
       onClick={() =>
         setContext((prev) => {
           return {

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -339,26 +339,37 @@ const SwitchShowcase = () => {
 };
 
 const TabsShowcase = () => {
+  const [submitCount, setSubmitCount] = React.useState(0);
+
   return (
     <Section
       testId="tabs"
       title="Tabs"
       description="Default tab and manual switching."
     >
-      <TabProvider defaultName="account">
-        <TabList>
-          <TabTrigger name="account">Account</TabTrigger>
-          <TabTrigger name="security">Security</TabTrigger>
-        </TabList>
-        <div className="pt-4">
-          <TabContent name="account">
-            <div>Account content</div>
-          </TabContent>
-          <TabContent name="security">
-            <div>Security content</div>
-          </TabContent>
-        </div>
-      </TabProvider>
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          setSubmitCount((count) => count + 1);
+        }}
+      >
+        <TabProvider defaultName="account">
+          <TabList>
+            <TabTrigger name="account">Account</TabTrigger>
+            <TabTrigger name="security">Security</TabTrigger>
+          </TabList>
+          <div className="pt-4">
+            <TabContent name="account">
+              <div>Account content</div>
+            </TabContent>
+            <TabContent name="security">
+              <div>Security content</div>
+            </TabContent>
+          </div>
+        </TabProvider>
+        <span data-testid="tabs-submit-count">{submitCount}</span>
+      </form>
     </Section>
   );
 };

--- a/packages/react/tests/tabs.spec.ts
+++ b/packages/react/tests/tabs.spec.ts
@@ -6,11 +6,15 @@ test("tabs show default content and switch on click", async ({ page }) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("tabs-section");
+  const submitCount = section.getByTestId("tabs-submit-count");
+
   await expect(section.getByText("Account content")).toBeVisible();
   await expect(section.getByText("Security content")).toHaveCount(0);
+  await expect(submitCount).toHaveText("0");
 
   await section.getByRole("button", { name: "Security" }).click();
 
   await expect(section.getByText("Account content")).toHaveCount(0);
   await expect(section.getByText("Security content")).toBeVisible();
+  await expect(submitCount).toHaveText("0");
 });


### PR DESCRIPTION
## Summary
- default `TabTrigger` buttons to `type="button"` so Tabs embedded in forms do not trigger accidental submits
- preserve `asChild` behavior and allow explicit `type` overrides for native button usage
- extend the Tabs Playwright harness/spec with a form-wrapped regression case that asserts tab switching does not submit the form

## Testing
- bun --filter react test:e2e tests/tabs.spec.ts
- bun run react:build

@p-sw please take a look.
