### PR TITLE
feat: add Toggle component

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] Table
   - [x] Tabs
   - [x] Toast
-  - [ ] Toggle
+  - [x] Toggle
   - [ ] Toggle Group
   - [x] Tooltip
 - CLI

--- a/packages/react/components/Toggle.tsx
+++ b/packages/react/components/Toggle.tsx
@@ -1,0 +1,81 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const toggleColors = {
+  disabled: "disabled:cursor-not-allowed disabled:opacity-50",
+  outline: "focus-visible:outline-black/10 dark:focus-visible:outline-white/20",
+  border: "border-neutral-300 dark:border-neutral-700",
+  background:
+    "bg-white hover:bg-neutral-100 dark:bg-black dark:hover:bg-neutral-900",
+  pressed:
+    "aria-pressed:bg-neutral-900 aria-pressed:text-white aria-pressed:hover:bg-neutral-800 dark:aria-pressed:bg-neutral-100 dark:aria-pressed:text-black dark:aria-pressed:hover:bg-neutral-200",
+};
+
+const [toggleVariants, resolveToggleVariantProps] = vcn({
+  base: `inline-flex w-fit items-center justify-center rounded-md border outline outline-1 outline-offset-2 outline-transparent transition-all ${toggleColors.border} ${toggleColors.background} ${toggleColors.pressed} ${toggleColors.outline} ${toggleColors.disabled}`,
+  variants: {
+    size: {
+      sm: "px-2 py-1 text-sm",
+      md: "px-3 py-2 text-base",
+      lg: "px-4 py-2 text-lg",
+    },
+  },
+  defaults: {
+    size: "md",
+  },
+});
+
+export interface ToggleProps
+  extends Omit<
+      React.ComponentPropsWithoutRef<"button">,
+      "aria-pressed" | "className"
+    >,
+    VariantProps<typeof toggleVariants> {
+  pressed?: boolean;
+  defaultPressed?: boolean;
+  onPressedChange?: (pressed: boolean) => void;
+}
+
+const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveToggleVariantProps(props);
+    const {
+      defaultPressed = false,
+      pressed: propPressed,
+      onClick,
+      onPressedChange,
+      type,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const [uncontrolledPressed, setUncontrolledPressed] =
+      React.useState(defaultPressed);
+    const isControlled = typeof propPressed === "boolean";
+    const pressed = propPressed ?? uncontrolledPressed;
+
+    return (
+      <button
+        {...otherPropsExtracted}
+        ref={ref}
+        type={type ?? "button"}
+        aria-pressed={pressed}
+        className={toggleVariants(variantProps)}
+        onClick={(event) => {
+          onClick?.(event);
+
+          if (event.defaultPrevented) return;
+
+          const nextPressed = !pressed;
+          if (!isControlled) {
+            setUncontrolledPressed(nextPressed);
+          }
+          onPressedChange?.(nextPressed);
+        }}
+      />
+    );
+  },
+);
+Toggle.displayName = "Toggle";
+
+export { Toggle };

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -53,6 +53,7 @@ import {
   TabTrigger,
 } from "../../components/Tabs";
 import { Toaster, useToast } from "../../components/Toast";
+import { Toggle } from "../../components/Toggle";
 import { Tooltip, TooltipContent } from "../../components/Tooltip";
 
 const Section = ({
@@ -338,6 +339,29 @@ const SwitchShowcase = () => {
   );
 };
 
+const ToggleShowcase = () => {
+  const [pressed, setPressed] = React.useState(false);
+
+  return (
+    <Section
+      testId="toggle"
+      title="Toggle"
+      description="Controlled pressed state and disabled behavior."
+    >
+      <div className="flex items-center gap-3">
+        <Toggle
+          pressed={pressed}
+          onPressedChange={setPressed}
+        >
+          Pin item
+        </Toggle>
+        <Toggle disabled>Disabled toggle</Toggle>
+        <span data-testid="toggle-state">{String(pressed)}</span>
+      </div>
+    </Section>
+  );
+};
+
 const TabsShowcase = () => {
   return (
     <Section
@@ -427,6 +451,7 @@ const showcases = [
   PopoverShowcase,
   SeparatorShowcase,
   SwitchShowcase,
+  ToggleShowcase,
   TabsShowcase,
   ToastShowcase,
   TooltipShowcase,

--- a/packages/react/tests/toggle.spec.ts
+++ b/packages/react/tests/toggle.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("toggle updates pressed state and disabled toggle remains disabled", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("toggle-section");
+  const toggle = section.getByRole("button", { name: "Pin item" });
+
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await toggle.click();
+
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(section.getByTestId("toggle-state")).toHaveText("true");
+  await expect(
+    section.getByRole("button", { name: "Disabled toggle" }),
+  ).toBeDisabled();
+});

--- a/registry.json
+++ b/registry.json
@@ -27,6 +27,7 @@
     "popover": { "type": "file", "name": "Popover.tsx" },
     "separator": { "type": "file", "name": "Separator.tsx" },
     "switch": { "type": "file", "name": "Switch.tsx" },
+    "toggle": { "type": "file", "name": "Toggle.tsx" },
     "tabs": {
       "type": "dir",
       "name": "Tabs",


### PR DESCRIPTION
## Summary
- add a new `Toggle` component with button-native pressed semantics and controlled/uncontrolled support
- add a focused Playwright harness showcase and regression coverage for pressed/disabled behavior
- register `toggle` in the component registry and mark the roadmap item complete

## Validation
- `bun --filter react test:e2e tests/toggle.spec.ts`
- `bun run react:build`

## Screenshot
![Toggle component screenshot](https://public.psw.kr/pswui-toggle-pr-18.png)

cc @p-sw
