### PR TITLE
fix(checkbox): improve keyboard accessibility

### DIFF
--- a/packages/react/components/Checkbox.tsx
+++ b/packages/react/components/Checkbox.tsx
@@ -21,7 +21,7 @@ const checkboxColors = {
 };
 
 const [checkboxVariant, resolveCheckboxVariantProps] = vcn({
-  base: `inline-block rounded-md ${checkboxColors.background.disabled} ${checkboxColors.background.default} ${checkboxColors.background.hover} ${checkboxColors.background.checked} ${checkboxColors.background.checkedHover} ${checkboxColors.background.disabledChecked} ${checkboxColors.background.disabledCheckedHover} has-[input[type="checkbox"]:disabled]:cursor-not-allowed transition-colors duration-150 ease-in-out`,
+  base: `relative inline-block rounded-md outline outline-1 outline-transparent outline-offset-2 has-[input[type="checkbox"]:focus-visible]:outline-black/10 dark:has-[input[type="checkbox"]:focus-visible]:outline-white/20 ${checkboxColors.background.disabled} ${checkboxColors.background.default} ${checkboxColors.background.hover} ${checkboxColors.background.checked} ${checkboxColors.background.checkedHover} ${checkboxColors.background.disabledChecked} ${checkboxColors.background.disabledCheckedHover} has-[input[type="checkbox"]:disabled]:cursor-not-allowed transition-colors duration-150 ease-in-out`,
   variants: {
     size: {
       base: "size-[1em] p-0 [&>svg]:size-[1em]",
@@ -80,7 +80,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
               }
             }}
             type="checkbox"
-            className="hidden"
+            className="absolute inset-0 m-0 size-full cursor-inherit opacity-0"
             ref={(el) => {
               internalRef.current = el;
               if (typeof ref === "function") {

--- a/packages/react/tests/checkbox.spec.ts
+++ b/packages/react/tests/checkbox.spec.ts
@@ -6,11 +6,28 @@ test("checkbox toggles checked state", async ({ page }) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("checkbox-section");
-  const control = section.getByTestId("checkbox-control");
-  const input = control.locator('input[type="checkbox"]');
+  const checkbox = section.getByRole("checkbox", { name: "Accept terms" });
 
-  await control.click();
+  await checkbox.click();
 
-  await expect(input).toBeChecked();
+  await expect(checkbox).toBeChecked();
+  await expect(section.getByTestId("checkbox-state")).toHaveText("true");
+});
+
+test("checkbox is focusable and toggles from the keyboard", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("checkbox-section");
+  const checkbox = section.getByRole("checkbox", { name: "Accept terms" });
+
+  await checkbox.focus();
+
+  await expect(checkbox).toBeFocused();
+
+  await page.keyboard.press("Space");
+
+  await expect(checkbox).toBeChecked();
   await expect(section.getByTestId("checkbox-state")).toHaveText("true");
 });


### PR DESCRIPTION
Summary
- keep the native Checkbox input keyboard-focusable and exposed to assistive technology instead of hiding it with `display: none`
- add a focus-visible outline on the wrapper so keyboard users get visible focus feedback
- strengthen the existing Playwright regression coverage to exercise accessible role queries and Space-key activation

Testing
- bun --filter react test:e2e tests/checkbox.spec.ts
- bun run react:build

cc @p-sw