### PR TITLE
feat: add Progress component

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] Navigation Menu
   - [ ] Pagination
   - [x] Popover
-  - [ ] Progress
+  - [x] Progress
   - [ ] Radio Group
   - [ ] Scroll Area
   - [ ] Select

--- a/packages/react/components/Progress.tsx
+++ b/packages/react/components/Progress.tsx
@@ -1,0 +1,56 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [progressVariant, resolveProgressVariantProps] = vcn({
+  base: "h-2 w-full overflow-hidden rounded-md border-0 bg-neutral-200 dark:bg-neutral-800 [&::-moz-progress-bar]:bg-neutral-900 [&::-webkit-progress-bar]:bg-transparent [&::-webkit-progress-value]:bg-neutral-900 dark:[&::-moz-progress-bar]:bg-neutral-100 dark:[&::-webkit-progress-value]:bg-neutral-100",
+  variants: {
+    size: {
+      sm: "h-1",
+      md: "h-2",
+      lg: "h-3",
+    },
+  },
+  defaults: {
+    size: "md",
+  },
+});
+
+interface ProgressProps
+  extends VariantProps<typeof progressVariant>,
+    Omit<
+      React.ComponentPropsWithoutRef<"progress">,
+      "className" | "max" | "value"
+    > {
+  max?: number;
+  value?: number | null;
+}
+
+const Progress = React.forwardRef<HTMLProgressElement, ProgressProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveProgressVariantProps(props);
+    const { max = 100, value, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const resolvedMax = Number.isFinite(max) && max > 0 ? max : 100;
+    const isDeterminate = typeof value === "number" && Number.isFinite(value);
+    const resolvedValue = isDeterminate
+      ? Math.min(Math.max(value, 0), resolvedMax)
+      : undefined;
+
+    return (
+      <progress
+        {...otherPropsExtracted}
+        ref={ref}
+        max={resolvedMax}
+        value={resolvedValue}
+        aria-valuemin={0}
+        aria-valuemax={resolvedMax}
+        aria-valuenow={resolvedValue}
+        className={progressVariant(variantProps)}
+      />
+    );
+  },
+);
+Progress.displayName = "Progress";
+
+export { Progress };

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -44,6 +44,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "../../components/Popover";
+import { Progress } from "../../components/Progress";
 import { Separator } from "../../components/Separator";
 import { Switch } from "../../components/Switch";
 import {
@@ -285,6 +286,31 @@ const PopoverShowcase = () => {
   );
 };
 
+const ProgressShowcase = () => {
+  const [value, setValue] = React.useState(40);
+
+  return (
+    <Section
+      testId="progress"
+      title="Progress"
+      description="Determinate and indeterminate progress state."
+    >
+      <div className="flex flex-col gap-4">
+        <Progress
+          aria-label="Upload progress"
+          value={value}
+          max={100}
+        />
+        <div className="flex items-center gap-3">
+          <Button onClick={() => setValue(75)}>Set progress to 75</Button>
+          <span data-testid="progress-value">{value}</span>
+        </div>
+        <Progress aria-label="Sync progress" />
+      </div>
+    </Section>
+  );
+};
+
 const SeparatorShowcase = () => {
   return (
     <Section
@@ -425,6 +451,7 @@ const showcases = [
   InputShowcase,
   LabelShowcase,
   PopoverShowcase,
+  ProgressShowcase,
   SeparatorShowcase,
   SwitchShowcase,
   TabsShowcase,

--- a/packages/react/tests/progress.spec.ts
+++ b/packages/react/tests/progress.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("progress exposes determinate and indeterminate state", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("progress-section");
+  const determinate = section.getByRole("progressbar", {
+    name: "Upload progress",
+  });
+  const indeterminate = section.getByRole("progressbar", {
+    name: "Sync progress",
+  });
+
+  await expect(determinate).toHaveAttribute("aria-valuenow", "40");
+  await expect(determinate).toHaveAttribute("aria-valuemax", "100");
+
+  await section.getByRole("button", { name: "Set progress to 75" }).click();
+
+  await expect(determinate).toHaveAttribute("aria-valuenow", "75");
+  await expect(section.getByTestId("progress-value")).toHaveText("75");
+  expect(await indeterminate.getAttribute("aria-valuenow")).toBeNull();
+});

--- a/registry.json
+++ b/registry.json
@@ -25,6 +25,7 @@
     "input": { "type": "file", "name": "Input.tsx" },
     "label": { "type": "file", "name": "Label.tsx" },
     "popover": { "type": "file", "name": "Popover.tsx" },
+    "progress": { "type": "file", "name": "Progress.tsx" },
     "separator": { "type": "file", "name": "Separator.tsx" },
     "switch": { "type": "file", "name": "Switch.tsx" },
     "tabs": {


### PR DESCRIPTION
## Summary
- add a new `Progress` component with native progressbar semantics, determinate clamping, and indeterminate support
- add a focused Playwright harness showcase and regression coverage for determinate and indeterminate progress states
- register `progress` in the component registry and mark the roadmap entry complete

## Validation
- `bun --filter react test:e2e tests/progress.spec.ts`
- `bun run react:build`

## Screenshot
![Progress component screenshot](https://public.psw.kr/pswui-ui-pr-20-progress.png)

cc @p-sw
