### PR TITLE
fix(switch): improve keyboard accessibility

### DIFF
--- a/packages/react/components/Switch.tsx
+++ b/packages/react/components/Switch.tsx
@@ -24,7 +24,7 @@ const switchColors = {
 };
 
 const [switchVariant, resolveSwitchVariantProps] = vcn({
-  base: `relative inline-block group/switch rounded-full p-1 has-[input[type=checkbox]:not(:checked)]:pr-5 has-[input[type=checkbox]:checked]:pl-5 ${switchColors.background.default} ${switchColors.background.hover} ${switchColors.background.checked} ${switchColors.background.checkedHover} ${switchColors.background.disabled} ${switchColors.background.disabledHover} ${switchColors.background.disabledChecked} ${switchColors.background.disabledCheckedHover} has-[input[type=checkbox]:disabled]:cursor-not-allowed transition-all duration-200 ease-in-out`,
+  base: `relative inline-block group/switch rounded-full p-1 outline outline-2 outline-offset-2 outline-transparent has-[input[type=checkbox]:focus-visible]:outline-black/20 dark:has-[input[type=checkbox]:focus-visible]:outline-white/30 has-[input[type=checkbox]:not(:checked)]:pr-5 has-[input[type=checkbox]:checked]:pl-5 ${switchColors.background.default} ${switchColors.background.hover} ${switchColors.background.checked} ${switchColors.background.checkedHover} ${switchColors.background.disabled} ${switchColors.background.disabledHover} ${switchColors.background.disabledChecked} ${switchColors.background.disabledCheckedHover} has-[input[type=checkbox]:disabled]:cursor-not-allowed transition-all duration-200 ease-in-out`,
   variants: {},
   defaults: {},
 });
@@ -42,6 +42,7 @@ const Switch = React.forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
     defaultChecked,
     checked: propChecked,
     onChange,
+    role,
     ...otherPropsExtracted
   } = otherPropsCompressed;
 
@@ -62,7 +63,8 @@ const Switch = React.forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
         defaultChecked={defaultChecked}
         checked={typeof defaultChecked === "boolean" ? undefined : checked}
         type="checkbox"
-        className="hidden"
+        role={role ?? "switch"}
+        className="absolute inset-0 m-0 h-full w-full cursor-pointer opacity-0 disabled:cursor-not-allowed"
         onChange={(e) => {
           setChecked(e.currentTarget.checked);
           onChange?.(e);

--- a/packages/react/tests/switch.spec.ts
+++ b/packages/react/tests/switch.spec.ts
@@ -6,10 +6,24 @@ test("switch toggles checked state", async ({ page }) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("switch-section");
-  const control = section.getByTestId("switch-control");
-  const input = control.locator('input[type="checkbox"]');
+  const input = section.getByRole("switch", { name: "Enable notifications" });
 
-  await control.click();
+  await input.click();
+
+  await expect(input).toBeChecked();
+  await expect(section.getByTestId("switch-state")).toHaveText("true");
+});
+
+test("switch toggles with Space from keyboard focus", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("switch-section");
+  const input = section.getByRole("switch", { name: "Enable notifications" });
+
+  await input.focus();
+  await expect(input).toBeFocused();
+
+  await page.keyboard.press("Space");
 
   await expect(input).toBeChecked();
   await expect(section.getByTestId("switch-state")).toHaveText("true");


### PR DESCRIPTION
## Summary
- keep the native Switch input focusable and accessible by using an invisible full-size checkbox overlay instead of `display: none`
- add visible focus feedback on the switch wrapper when the native control receives keyboard focus
- strengthen the Playwright coverage to query the switch by accessible role/name and verify Space-key toggling

## Testing
- bun --filter react test:e2e tests/switch.spec.ts
- bun run react:build

cc @p-sw