### PR TITLE
feat: add Skeleton component

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] Scroll Area
   - [ ] Select
   - [x] Separator
-  - [ ] Skeleton
+  - [x] Skeleton
   - [ ] Slider
   - [x] Switch
   - [ ] Table

--- a/packages/react/components/Skeleton.tsx
+++ b/packages/react/components/Skeleton.tsx
@@ -1,0 +1,48 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [skeletonVariant, resolveSkeletonVariantProps] = vcn({
+  base: "block animate-pulse bg-neutral-200 dark:bg-neutral-800",
+  variants: {
+    shape: {
+      rectangle: "rounded-md",
+      circle: "rounded-full",
+      text: "rounded-md",
+    },
+    size: {
+      sm: "h-3 w-full",
+      md: "h-4 w-full",
+      lg: "h-6 w-full",
+      icon: "size-10",
+    },
+  },
+  defaults: {
+    shape: "rectangle",
+    size: "md",
+  },
+});
+
+interface SkeletonProps
+  extends VariantProps<typeof skeletonVariant>,
+    Omit<React.ComponentPropsWithoutRef<"div">, "className"> {}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveSkeletonVariantProps(props);
+    const { "aria-hidden": ariaHidden, ...otherPropsExtracted } =
+      otherPropsCompressed;
+
+    return (
+      <div
+        ref={ref}
+        aria-hidden={ariaHidden ?? true}
+        className={skeletonVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+Skeleton.displayName = "Skeleton";
+
+export { Skeleton };

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -45,6 +45,7 @@ import {
   PopoverTrigger,
 } from "../../components/Popover";
 import { Separator } from "../../components/Separator";
+import { Skeleton } from "../../components/Skeleton";
 import { Switch } from "../../components/Switch";
 import {
   TabContent,
@@ -315,6 +316,47 @@ const SeparatorShowcase = () => {
   );
 };
 
+const SkeletonShowcase = () => {
+  return (
+    <Section
+      testId="skeleton"
+      title="Skeleton"
+      description="Loading placeholder blocks with shape and size variants."
+    >
+      <div
+        data-testid="skeleton-card"
+        className="flex w-full max-w-sm flex-col gap-3"
+      >
+        <div className="flex items-center gap-3">
+          <Skeleton
+            data-testid="skeleton-avatar"
+            shape="circle"
+            size="icon"
+          />
+          <div className="flex flex-1 flex-col gap-2">
+            <Skeleton
+              data-testid="skeleton-title"
+              size="lg"
+              className="w-48"
+            />
+            <Skeleton
+              data-testid="skeleton-subtitle"
+              size="sm"
+              className="w-32"
+            />
+          </div>
+        </div>
+        <Skeleton data-testid="skeleton-line" />
+        <Skeleton
+          data-testid="skeleton-short-line"
+          size="sm"
+          className="w-2/3"
+        />
+      </div>
+    </Section>
+  );
+};
+
 const SwitchShowcase = () => {
   const [checked, setChecked] = React.useState(false);
 
@@ -426,6 +468,7 @@ const showcases = [
   LabelShowcase,
   PopoverShowcase,
   SeparatorShowcase,
+  SkeletonShowcase,
   SwitchShowcase,
   TabsShowcase,
   ToastShowcase,

--- a/packages/react/tests/skeleton.spec.ts
+++ b/packages/react/tests/skeleton.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("skeleton renders decorative placeholders with shape and size variants", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("skeleton-section");
+  const avatar = section.getByTestId("skeleton-avatar");
+  const title = section.getByTestId("skeleton-title");
+  const line = section.getByTestId("skeleton-line");
+  const shortLine = section.getByTestId("skeleton-short-line");
+
+  await expect(avatar).toBeVisible();
+  await expect(title).toBeVisible();
+  await expect(line).toBeVisible();
+  await expect(shortLine).toBeVisible();
+
+  await expect(avatar).toHaveAttribute("aria-hidden", "true");
+  await expect(avatar).toHaveClass(/rounded-full/);
+  await expect(title).toHaveClass(/h-6/);
+  await expect(title).toHaveClass(/w-48/);
+  await expect(line).toHaveClass(/animate-pulse/);
+  await expect(shortLine).toHaveClass(/w-2\/3/);
+
+  const avatarBox = await avatar.boundingBox();
+  expect(avatarBox?.width).toBeGreaterThan(0);
+  expect(avatarBox?.width).toBe(avatarBox?.height);
+});

--- a/registry.json
+++ b/registry.json
@@ -26,6 +26,7 @@
     "label": { "type": "file", "name": "Label.tsx" },
     "popover": { "type": "file", "name": "Popover.tsx" },
     "separator": { "type": "file", "name": "Separator.tsx" },
+    "skeleton": { "type": "file", "name": "Skeleton.tsx" },
     "switch": { "type": "file", "name": "Switch.tsx" },
     "tabs": {
       "type": "dir",


### PR DESCRIPTION
## Summary
- add a new `Skeleton` component with simple shape and size variants for reusable loading placeholders
- add a focused Playwright harness showcase and regression coverage for the new component
- register `skeleton` in the component registry and mark the roadmap item complete in the README

## Testing
- bun install
- bun --filter react test:e2e tests/skeleton.spec.ts
- bun run react:build

## Screenshot
![Skeleton component preview](https://public.psw.kr/pswui-skeleton-pr-22.png)

cc @p-sw
