### PR TITLE
fix: improve dialog escape handling

### DIFF
--- a/packages/react/components/Dialog/Component.tsx
+++ b/packages/react/components/Dialog/Component.tsx
@@ -5,7 +5,13 @@ import {
   useDocument,
   vcn,
 } from "@pswui-lib";
-import React, { type ReactNode, useId, useRef, useState } from "react";
+import React, {
+  type ReactNode,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import ReactDOM from "react-dom";
 
 import {
@@ -99,6 +105,23 @@ const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlay>(
     const { isMounted, isRendered } = useAnimatedMount(opened, internalRef);
 
     const document = useDocument();
+
+    useEffect(() => {
+      if (!document || !opened) return;
+
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.defaultPrevented || event.key !== "Escape") return;
+
+        setContext((prev) => ({ ...prev, opened: false }));
+      };
+
+      document.addEventListener("keydown", onKeyDown);
+
+      return () => {
+        document.removeEventListener("keydown", onKeyDown);
+      };
+    }, [document, opened, setContext]);
+
     if (!document) return null;
 
     return isMounted
@@ -173,11 +196,28 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
       resolveDialogContentVariant(props);
     const { isRendered } = useInnerDialogContext();
     const { children, onClick, ...otherPropsExtracted } = otherPropsCompressed;
+    const internalRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      if (!isRendered) return;
+
+      internalRef.current?.focus();
+    }, [isRendered]);
+
     return (
       <div
         {...otherPropsExtracted}
-        ref={ref}
+        ref={(el) => {
+          internalRef.current = el;
+          if (typeof ref === "function") {
+            ref(el);
+          } else if (ref) {
+            ref.current = el;
+          }
+        }}
         role="dialog"
+        tabIndex={-1}
+        aria-modal="true"
         aria-labelledby={ids.title}
         aria-describedby={ids.description}
         className={dialogContentVariant({

--- a/packages/react/tests/dialog.spec.ts
+++ b/packages/react/tests/dialog.spec.ts
@@ -10,8 +10,23 @@ test("dialog opens and closes", async ({ page }) => {
 
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
+  await expect(dialog).toHaveAttribute("aria-modal", "true");
   await expect(dialog).toContainText("Dialog description");
 
   await page.getByRole("button", { name: "Close dialog" }).click();
+  await expect(dialog).not.toBeVisible();
+});
+
+test("dialog closes on Escape", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("dialog-section");
+  await section.getByRole("button", { name: "Open dialog" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  await page.keyboard.press("Escape");
+
   await expect(dialog).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary
- close the existing Dialog when Escape is pressed while it is open
- focus dialog content on open and mark it as `aria-modal="true"`
- add Playwright coverage for Escape dismissal and modal semantics

## Testing
- bun --filter react test:e2e tests/dialog.spec.ts
- bun run react:build

cc @p-sw
