### PR TITLE
feat(react): add alert component

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] Form
   - [ ] Textarea
   - [ ] Accordion
-  - [ ] Alert
+  - [x] Alert
   - [ ] Avatar
   - [ ] Badge
   - [ ] Breadcrumb

--- a/packages/react/components/Alert.tsx
+++ b/packages/react/components/Alert.tsx
@@ -1,0 +1,105 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [alertVariant, resolveAlertVariantProps] = vcn({
+  base: "flex flex-col gap-2 rounded-lg border p-4 text-neutral-950 shadow-sm dark:text-neutral-50",
+  variants: {
+    status: {
+      default:
+        "border-neutral-200 bg-white dark:border-neutral-800 dark:bg-black",
+      success:
+        "border-green-400 bg-green-50 dark:border-green-600 dark:bg-green-950/40",
+      warning:
+        "border-yellow-400 bg-yellow-50 dark:border-yellow-600 dark:bg-yellow-950/40",
+      danger: "border-red-400 bg-red-50 dark:border-red-600 dark:bg-red-950/40",
+    },
+  },
+  defaults: {
+    status: "default",
+  },
+});
+
+interface AlertProps
+  extends VariantProps<typeof alertVariant>,
+    React.ComponentPropsWithoutRef<"section">,
+    AsChild {}
+
+const Alert = React.forwardRef<HTMLElement, AlertProps>((props, ref) => {
+  const [variantProps, otherPropsCompressed] = resolveAlertVariantProps(props);
+  const { asChild, role, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "section";
+
+  return (
+    <Comp
+      ref={ref}
+      role={role ?? "alert"}
+      className={alertVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+Alert.displayName = "Alert";
+
+const [alertTitleVariant, resolveAlertTitleVariantProps] = vcn({
+  base: "text-base font-semibold leading-none tracking-tight",
+  variants: {},
+  defaults: {},
+});
+
+interface AlertTitleProps
+  extends VariantProps<typeof alertTitleVariant>,
+    React.ComponentPropsWithoutRef<"h5">,
+    AsChild {}
+
+const AlertTitle = React.forwardRef<HTMLHeadingElement, AlertTitleProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveAlertTitleVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "h5";
+
+    return (
+      <Comp
+        ref={ref}
+        className={alertTitleVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+AlertTitle.displayName = "AlertTitle";
+
+const [alertDescriptionVariant, resolveAlertDescriptionVariantProps] = vcn({
+  base: "text-sm text-neutral-600 dark:text-neutral-300",
+  variants: {},
+  defaults: {},
+});
+
+interface AlertDescriptionProps
+  extends VariantProps<typeof alertDescriptionVariant>,
+    React.ComponentPropsWithoutRef<"p">,
+    AsChild {}
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  AlertDescriptionProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveAlertDescriptionVariantProps(props);
+  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "p";
+
+  return (
+    <Comp
+      ref={ref}
+      className={alertDescriptionVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/packages/react/tests/alert.spec.ts
+++ b/packages/react/tests/alert.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("alert renders semantic structure and supports status variants", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("alert-section");
+  const defaultAlert = section.getByTestId("alert-default");
+  const successAlert = section.getByTestId("alert-success");
+
+  await expect(defaultAlert).toHaveJSProperty("tagName", "SECTION");
+  await expect(defaultAlert).toHaveAttribute("role", "alert");
+  await expect(
+    defaultAlert.getByRole("heading", { level: 5, name: "Heads up" }),
+  ).toBeVisible();
+  await expect(
+    defaultAlert.getByText(
+      "This default alert keeps the content compact and readable.",
+    ),
+  ).toHaveJSProperty("tagName", "P");
+
+  await expect(successAlert).toHaveAttribute("role", "alert");
+  await expect(
+    successAlert.getByRole("heading", { level: 5, name: "Changes saved" }),
+  ).toBeVisible();
+  await expect(successAlert).toContainText(
+    "Your profile settings were stored successfully.",
+  );
+});

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Alert, AlertDescription, AlertTitle } from "../../components/Alert";
 import { Button } from "../../components/Button";
 import {
   Card,
@@ -77,6 +78,34 @@ const Section = ({
       </div>
       {children}
     </section>
+  );
+};
+
+const AlertShowcase = () => {
+  return (
+    <Section
+      testId="alert"
+      title="Alert"
+      description="Semantic alerts with compact status variants."
+    >
+      <div className="flex flex-col gap-3">
+        <Alert data-testid="alert-default">
+          <AlertTitle>Heads up</AlertTitle>
+          <AlertDescription>
+            This default alert keeps the content compact and readable.
+          </AlertDescription>
+        </Alert>
+        <Alert
+          status="success"
+          data-testid="alert-success"
+        >
+          <AlertTitle>Changes saved</AlertTitle>
+          <AlertDescription>
+            Your profile settings were stored successfully.
+          </AlertDescription>
+        </Alert>
+      </div>
+    </Section>
   );
 };
 
@@ -416,6 +445,7 @@ const TooltipShowcase = () => {
 };
 
 const showcases = [
+  AlertShowcase,
   ButtonShowcase,
   CardShowcase,
   CheckboxShowcase,

--- a/registry.json
+++ b/registry.json
@@ -12,6 +12,7 @@
     "useAnimatedMount.ts"
   ],
   "components": {
+    "alert": { "type": "file", "name": "Alert.tsx" },
     "button": { "type": "file", "name": "Button.tsx" },
     "card": { "type": "file", "name": "Card.tsx" },
     "checkbox": { "type": "file", "name": "Checkbox.tsx" },


### PR DESCRIPTION
## Summary
- add a new `Alert` component family with semantic `Alert`, `AlertTitle`, and `AlertDescription` primitives
- add a focused Playwright harness showcase and regression coverage for default and success alert states
- register `alert` in `registry.json` and mark Alert complete in the README roadmap

## Testing
- bun install
- bun --filter react test:e2e tests/alert.spec.ts
- bun run react:build

## Screenshot
![Alert component screenshot](https://public.psw.kr/pswui-alert-pr-24.png)

cc @p-sw
