### PR TITLE
fix: close Drawer on Escape

### DIFF
--- a/packages/react/components/Drawer.tsx
+++ b/packages/react/components/Drawer.tsx
@@ -109,6 +109,7 @@ const DrawerOverlay = forwardRef<HTMLDivElement, DrawerOverlayProps>(
   (props, ref) => {
     const internalRef = useRef<HTMLDivElement | null>(null);
     const [state, setState] = useContext(DrawerContext);
+    const document = useDocument();
 
     const { isMounted, isRendered } = useAnimatedMount(
       state.isDragging ? true : state.opened,
@@ -127,6 +128,20 @@ const DrawerOverlay = forwardRef<HTMLDivElement, DrawerOverlayProps>(
       setState((prev) => ({ ...prev, opened: false }));
     }
 
+    useEffect(() => {
+      if (!document || !state.opened) return;
+
+      function onKeyDown(event: KeyboardEvent) {
+        if (event.key !== "Escape" || event.defaultPrevented) return;
+        setState((prev) => (prev.opened ? { ...prev, opened: false } : prev));
+      }
+
+      document.addEventListener("keydown", onKeyDown);
+      return () => {
+        document.removeEventListener("keydown", onKeyDown);
+      };
+    }, [document, state.opened, setState]);
+
     const Comp = asChild ? Slot : "div";
     const backdropFilter = `brightness(${
       state.isDragging
@@ -136,7 +151,6 @@ const DrawerOverlay = forwardRef<HTMLDivElement, DrawerOverlayProps>(
           : 1
     })`;
 
-    const document = useDocument();
     if (!document) return null;
 
     return (
@@ -247,11 +261,17 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
     const [variantProps, restPropsCompressed] =
       resolveDrawerContentVariantProps(props);
     const { position = "left" } = variantProps;
-    const { asChild, onClick, ...restPropsExtracted } = restPropsCompressed;
+    const { asChild, onClick, onKeyDown, ...restPropsExtracted } =
+      restPropsCompressed;
 
     const Comp = asChild ? Slot : "div";
 
     const internalRef = useRef<HTMLDivElement | null>(null);
+
+    function onEscapeKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      setState((prev) => (prev.opened ? { ...prev, opened: false } : prev));
+    }
 
     function onMouseDown() {
       setState((prev) => ({ ...prev, isDragging: true }));
@@ -427,6 +447,10 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
           onClick={(e) => {
             e.stopPropagation();
             onClick?.(e);
+          }}
+          onKeyDown={(e) => {
+            onKeyDown?.(e);
+            onEscapeKeyDown(e);
           }}
           onMouseDown={onMouseDown}
           onMouseLeave={() =>

--- a/packages/react/tests/drawer.spec.ts
+++ b/packages/react/tests/drawer.spec.ts
@@ -14,3 +14,17 @@ test("drawer opens and closes", async ({ page }) => {
   await closeButton.click();
   await expect(closeButton).not.toBeVisible();
 });
+
+test("drawer closes on Escape", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("drawer-section");
+  await section.getByRole("button", { name: "Open drawer" }).click();
+
+  const closeButton = page.getByRole("button", { name: "Close drawer" });
+
+  await expect(closeButton).toBeVisible();
+  await closeButton.focus();
+  await closeButton.press("Escape");
+  await expect(closeButton).not.toBeVisible();
+});


### PR DESCRIPTION
## Summary
- close the existing Drawer when Escape is pressed while it is open
- add a focused Playwright regression test for Escape dismissal
- keep the change scoped to Drawer only

## Validation
- bun install
- bun --filter react test:e2e tests/drawer.spec.ts
- bun run react:build

@p-sw please review.