### PR TITLE
feat: add avatar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] Textarea
   - [ ] Accordion
   - [x] Alert
-  - [ ] Avatar
+  - [x] Avatar
   - [ ] Badge
   - [ ] Breadcrumb
   - [x] Button

--- a/packages/react/components/Avatar.tsx
+++ b/packages/react/components/Avatar.tsx
@@ -1,0 +1,147 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [avatarVariants, resolveAvatarVariantProps] = vcn({
+  base: "relative inline-flex shrink-0 select-none items-center justify-center overflow-hidden border border-neutral-200 bg-neutral-100 font-medium text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200",
+  variants: {
+    size: {
+      sm: "size-8 text-xs",
+      md: "size-10 text-sm",
+      lg: "size-14 text-lg",
+    },
+    shape: {
+      circle: "rounded-full",
+      square: "rounded-lg",
+    },
+  },
+  defaults: {
+    size: "md",
+    shape: "circle",
+  },
+});
+
+type ImageStatus = "idle" | "loading" | "loaded" | "error";
+
+type AvatarImageProps = Omit<
+  React.ComponentPropsWithoutRef<"img">,
+  "alt" | "children" | "src"
+>;
+
+export interface AvatarProps
+  extends VariantProps<typeof avatarVariants>,
+    Omit<React.ComponentPropsWithoutRef<"div">, "children"> {
+  src?: string;
+  alt?: string;
+  name?: string;
+  fallback?: React.ReactNode;
+  imageProps?: AvatarImageProps;
+}
+
+function getInitials(name?: string) {
+  const words = name?.trim().split(/\s+/).filter(Boolean) ?? [];
+
+  if (words.length === 0) {
+    return null;
+  }
+
+  return words
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function getFallbackLabel({
+  alt,
+  name,
+  fallback,
+}: Pick<AvatarProps, "alt" | "name" | "fallback">) {
+  if (alt && alt.length > 0) {
+    return alt;
+  }
+
+  if (name && name.length > 0) {
+    return name;
+  }
+
+  if (typeof fallback === "string" && fallback.length > 0) {
+    return fallback;
+  }
+
+  return "Avatar";
+}
+
+const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
+  const [variantProps, otherPropsCompressed] = resolveAvatarVariantProps(props);
+  const {
+    src,
+    alt,
+    name,
+    fallback,
+    imageProps,
+    role,
+    "aria-hidden": ariaHidden,
+    "aria-label": ariaLabel,
+    ...otherPropsExtracted
+  } = otherPropsCompressed;
+  const isAriaHidden = ariaHidden === true || ariaHidden === "true";
+
+  const [imageStatus, setImageStatus] = React.useState<ImageStatus>(
+    src ? "loading" : "idle",
+  );
+
+  React.useEffect(() => {
+    setImageStatus(src ? "loading" : "idle");
+  }, [src]);
+
+  const fallbackContent = fallback ?? getInitials(name) ?? "?";
+  const fallbackLabel = ariaLabel ?? getFallbackLabel({ alt, name, fallback });
+  const showFallback = !src || imageStatus !== "loaded";
+  const showImage = Boolean(src) && imageStatus !== "error";
+
+  return (
+    <div
+      ref={ref}
+      className={avatarVariants(variantProps)}
+      data-state={showFallback ? "fallback" : "loaded"}
+      role={!isAriaHidden && showFallback ? role ?? "img" : role}
+      aria-hidden={ariaHidden}
+      aria-label={!isAriaHidden && showFallback ? fallbackLabel : ariaLabel}
+      {...otherPropsExtracted}
+    >
+      {showImage ? (
+        <img
+          {...imageProps}
+          src={src}
+          alt={alt ?? name ?? ""}
+          ref={(element) => {
+            if (element?.complete) {
+              setImageStatus(element.naturalWidth > 0 ? "loaded" : "error");
+            }
+          }}
+          className={`absolute inset-0 size-full object-cover ${
+            imageStatus === "loaded" ? "" : "hidden"
+          } ${imageProps?.className ?? ""}`}
+          onLoad={(event) => {
+            setImageStatus("loaded");
+            imageProps?.onLoad?.(event);
+          }}
+          onError={(event) => {
+            setImageStatus("error");
+            imageProps?.onError?.(event);
+          }}
+        />
+      ) : null}
+      {showFallback ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none leading-none uppercase"
+        >
+          {fallbackContent}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+Avatar.displayName = "Avatar";
+
+export { Avatar };

--- a/packages/react/public/avatar-demo.svg
+++ b/packages/react/public/avatar-demo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#111827" />
+  <circle cx="32" cy="24" r="12" fill="#F5F5F5" />
+  <path
+    d="M14 56C17 46 25 40 32 40C39 40 47 46 50 56"
+    fill="#F5F5F5"
+  />
+</svg>

--- a/packages/react/tests/avatar.spec.ts
+++ b/packages/react/tests/avatar.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("avatar shows image content and falls back accessibly on image failure", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("avatar-section");
+  const loadedAvatar = section.getByTestId("avatar-image");
+  const fallbackAvatar = section.getByTestId("avatar-fallback");
+
+  await expect(loadedAvatar).toHaveAttribute("data-state", "loaded");
+  await expect(
+    loadedAvatar.getByRole("img", { name: "Taylor Lane" }),
+  ).toBeVisible();
+
+  await expect(fallbackAvatar).toHaveAttribute("data-state", "fallback");
+  await expect(fallbackAvatar).toHaveAttribute("role", "img");
+  await expect(fallbackAvatar).toHaveAttribute("aria-label", "Ada Lovelace");
+  await expect(fallbackAvatar.locator("img")).toHaveCount(0);
+  await expect(fallbackAvatar).toContainText("AL");
+});

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "../../components/Alert";
+import { Avatar } from "../../components/Avatar";
 import { Button } from "../../components/Button";
 import {
   Card,
@@ -56,6 +57,8 @@ import {
 import { Toaster, useToast } from "../../components/Toast";
 import { Tooltip, TooltipContent } from "../../components/Tooltip";
 
+const avatarImageSrc = "/avatar-demo.svg";
+
 const Section = ({
   testId,
   title,
@@ -78,6 +81,29 @@ const Section = ({
       </div>
       {children}
     </section>
+  );
+};
+
+const AvatarShowcase = () => {
+  return (
+    <Section
+      testId="avatar"
+      title="Avatar"
+      description="Image avatars fall back to initials when an image is missing."
+    >
+      <div className="flex flex-wrap items-center gap-4">
+        <Avatar
+          data-testid="avatar-image"
+          src={avatarImageSrc}
+          name="Taylor Lane"
+        />
+        <Avatar
+          data-testid="avatar-fallback"
+          src="/avatar-missing.png"
+          name="Ada Lovelace"
+        />
+      </div>
+    </Section>
   );
 };
 
@@ -446,6 +472,7 @@ const TooltipShowcase = () => {
 
 const showcases = [
   AlertShowcase,
+  AvatarShowcase,
   ButtonShowcase,
   CardShowcase,
   CheckboxShowcase,

--- a/registry.json
+++ b/registry.json
@@ -13,6 +13,7 @@
   ],
   "components": {
     "alert": { "type": "file", "name": "Alert.tsx" },
+    "avatar": { "type": "file", "name": "Avatar.tsx" },
     "button": { "type": "file", "name": "Button.tsx" },
     "card": { "type": "file", "name": "Card.tsx" },
     "checkbox": { "type": "file", "name": "Checkbox.tsx" },


### PR DESCRIPTION
## Summary
- add a new `Avatar` component with image loading/error handling and accessible initials fallback
- add Playwright harness coverage and a focused Avatar e2e spec
- register the component and mark Avatar complete in the README roadmap

## Verification
- `bun run react:test:e2e -- tests/avatar.spec.ts`
- `bun run react:build`

## Screenshot
![Avatar component preview](https://public.psw.kr/pswui-avatar-pr-26.png)

@p-sw
