### PR TITLE
fix(form): associate field help and errors

### DIFF
--- a/packages/react/components/Form.tsx
+++ b/packages/react/components/Form.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   useContext,
   useEffect,
+  useId,
   useRef,
 } from "react";
 
@@ -13,8 +14,30 @@ Form Item Context
 **/
 interface IFormItemContext {
   invalid?: string | null | undefined;
+  labelId?: string;
+  helperId?: string;
+  errorId?: string;
 }
 const FormItemContext = createContext<IFormItemContext>({});
+
+const mergeIds = (...parts: Array<string | null | undefined>) => {
+  const ids = parts.flatMap((part) => part?.split(/\s+/) ?? []).filter(Boolean);
+
+  return ids.length ? Array.from(new Set(ids)).join(" ") : undefined;
+};
+
+const setOrRemoveAttribute = (
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  name: string,
+  value?: string,
+) => {
+  if (value) {
+    element.setAttribute(name, value);
+    return;
+  }
+
+  element.removeAttribute(name);
+};
 
 /**
 FormItem
@@ -38,20 +61,69 @@ const FormItem = forwardRef<HTMLLabelElement, FormItemProps>((props, ref) => {
   const { asChild, children, invalid, ...restPropsExtracted } =
     restPropsCompressed;
   const innerRef = useRef<HTMLLabelElement | null>(null);
+  const labelId = useId();
+  const helperId = useId();
+  const errorId = useId();
+  const initialAriaLabelledBy = useRef<string | null | undefined>(undefined);
+  const initialAriaDescribedBy = useRef<string | null | undefined>(undefined);
+  const initialAriaErrorMessage = useRef<string | null | undefined>(undefined);
 
   useEffect(() => {
     const invalidAsString = invalid ? invalid : "";
 
-    const input = innerRef.current?.querySelector?.("input");
-    if (!input) return;
+    const field = innerRef.current?.querySelector?.<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >("input, textarea, select");
+    if (!field) return;
 
-    input.setCustomValidity(invalidAsString);
+    if (initialAriaLabelledBy.current === undefined) {
+      initialAriaLabelledBy.current = field.getAttribute("aria-labelledby");
+    }
+    if (initialAriaDescribedBy.current === undefined) {
+      initialAriaDescribedBy.current = field.getAttribute("aria-describedby");
+    }
+    if (initialAriaErrorMessage.current === undefined) {
+      initialAriaErrorMessage.current = field.getAttribute("aria-errormessage");
+    }
+
+    const label =
+      innerRef.current?.querySelector<HTMLElement>("[data-form-label]");
+    const helper =
+      innerRef.current?.querySelector<HTMLElement>("[data-form-helper]");
+    const error =
+      innerRef.current?.querySelector<HTMLElement>("[data-form-error]");
+
+    field.setCustomValidity(invalidAsString);
+    setOrRemoveAttribute(
+      field,
+      "aria-labelledby",
+      mergeIds(initialAriaLabelledBy.current, label?.id),
+    );
+    setOrRemoveAttribute(
+      field,
+      "aria-describedby",
+      mergeIds(initialAriaDescribedBy.current, helper?.id, error?.id),
+    );
+    setOrRemoveAttribute(
+      field,
+      "aria-errormessage",
+      invalid
+        ? mergeIds(initialAriaErrorMessage.current, error?.id)
+        : initialAriaErrorMessage.current ?? undefined,
+    );
+
+    if (invalid) {
+      field.setAttribute("aria-invalid", "true");
+      return;
+    }
+
+    field.removeAttribute("aria-invalid");
   }, [invalid]);
 
   const Comp = asChild ? Slot : "label";
 
   return (
-    <FormItemContext.Provider value={{ invalid }}>
+    <FormItemContext.Provider value={{ invalid, labelId, helperId, errorId }}>
       <Comp
         ref={(el: HTMLLabelElement | null) => {
           innerRef.current = el;
@@ -89,12 +161,15 @@ const FormLabel = forwardRef<HTMLSpanElement, FormLabelProps>((props, ref) => {
   const [variantProps, otherPropsCompressed] =
     resolveFormLabelVariantProps(props);
   const { children, asChild, ...otherPropsExtracted } = otherPropsCompressed;
+  const item = useContext(FormItemContext);
 
   const Comp = asChild ? Slot : "span";
 
   return (
     <Comp
       ref={ref}
+      id={otherPropsExtracted.id ?? item.labelId}
+      data-form-label=""
       className={formLabelVariant(variantProps)}
       {...otherPropsExtracted}
     >
@@ -135,6 +210,8 @@ const FormHelper = forwardRef<HTMLSpanElement, FormHelperProps>(
     return (
       <Comp
         ref={ref}
+        id={otherPropsExtracted.id ?? item.helperId}
+        data-form-helper=""
         className={formHelperVariant(variantProps)}
         {...otherPropsExtracted}
       >
@@ -171,6 +248,8 @@ const FormError = forwardRef<HTMLSpanElement, FormErrorProps>((props, ref) => {
   return item.invalid ? (
     <Comp
       ref={ref}
+      id={otherPropsExtracted.id ?? item.errorId}
+      data-form-error=""
       className={formErrorVariant(variantProps)}
       {...otherPropsExtracted}
     >

--- a/packages/react/tests/form.spec.ts
+++ b/packages/react/tests/form.spec.ts
@@ -8,12 +8,54 @@ test("form surfaces invalid state through error and input validity", async ({
   await gotoHarness(page);
 
   const section = page.getByTestId("form-section");
-  await expect(section.getByTestId("form-error")).toHaveText("Required field");
+  const invalidField = section.getByTestId("form-invalid-input");
+  const validField = section.getByTestId("form-valid-input");
+  const error = section.getByTestId("form-error");
+  const helper = section.getByTestId("form-helper");
+
+  await expect(error).toHaveText("Required field");
   await expect(section.getByText("Helpful instructions")).toHaveCount(0);
+  await expect(helper).toHaveText("Send a work email we can reach.");
 
-  const hasCustomError = await section
-    .getByLabel("Form name")
-    .evaluate((element) => (element as HTMLInputElement).validity.customError);
+  const invalidFieldAttributes = await invalidField.evaluate((element) => {
+    const input = element as HTMLInputElement;
+    return {
+      customError: input.validity.customError,
+      ariaDescribedBy: input.getAttribute("aria-describedby"),
+      ariaErrorMessage: input.getAttribute("aria-errormessage"),
+      ariaInvalid: input.getAttribute("aria-invalid"),
+      ariaLabelledBy: input.getAttribute("aria-labelledby"),
+    };
+  });
 
-  expect(hasCustomError).toBe(true);
+  const errorId = await error.getAttribute("id");
+  const nameLabelId = await section
+    .getByText("Name", { exact: true })
+    .getAttribute("id");
+
+  expect(invalidFieldAttributes.customError).toBe(true);
+  expect(invalidFieldAttributes.ariaDescribedBy).toBe(errorId);
+  expect(invalidFieldAttributes.ariaErrorMessage).toBe(errorId);
+  expect(invalidFieldAttributes.ariaInvalid).toBe("true");
+  expect(invalidFieldAttributes.ariaLabelledBy).toBe(nameLabelId);
+
+  const validFieldAttributes = await validField.evaluate((element) => {
+    const input = element as HTMLInputElement;
+    return {
+      ariaDescribedBy: input.getAttribute("aria-describedby"),
+      ariaErrorMessage: input.getAttribute("aria-errormessage"),
+      ariaInvalid: input.getAttribute("aria-invalid"),
+      ariaLabelledBy: input.getAttribute("aria-labelledby"),
+    };
+  });
+
+  const helperId = await helper.getAttribute("id");
+  const emailLabelId = await section
+    .getByText("Email", { exact: true })
+    .getAttribute("id");
+
+  expect(validFieldAttributes.ariaDescribedBy).toBe(helperId);
+  expect(validFieldAttributes.ariaErrorMessage).toBeNull();
+  expect(validFieldAttributes.ariaInvalid).toBeNull();
+  expect(validFieldAttributes.ariaLabelledBy).toBe(emailLabelId);
 });

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -241,17 +241,33 @@ const FormShowcase = () => {
     <Section
       testId="form"
       title="Form"
-      description="Helper and error text driven by invalid state."
+      description="Helper and error text remain associated with their field."
     >
-      <FormItem invalid="Required field">
-        <FormLabel>Name</FormLabel>
-        <Input
-          aria-label="Form name"
-          type="text"
-        />
-        <FormHelper hiddenOnInvalid>Helpful instructions</FormHelper>
-        <FormError data-testid="form-error" />
-      </FormItem>
+      <div className="flex w-full flex-col gap-6">
+        <FormItem invalid="Required field">
+          <FormLabel>Name</FormLabel>
+          <Input
+            aria-label="Form name"
+            data-testid="form-invalid-input"
+            type="text"
+          />
+          <FormHelper hiddenOnInvalid>Helpful instructions</FormHelper>
+          <FormError data-testid="form-error" />
+        </FormItem>
+
+        <FormItem>
+          <FormLabel>Email</FormLabel>
+          <Input
+            aria-label="Form email"
+            data-testid="form-valid-input"
+            type="email"
+          />
+          <FormHelper data-testid="form-helper">
+            Send a work email we can reach.
+          </FormHelper>
+          <FormError />
+        </FormItem>
+      </div>
     </Section>
   );
 };


### PR DESCRIPTION
## Summary
- associate each `FormItem` field with its rendered label, helper, and error content via stable ARIA ids
- preserve the existing custom validity behavior while exposing `aria-invalid` and `aria-errormessage` for invalid fields
- strengthen the Playwright harness/spec to cover both invalid error association and valid helper association

## Testing
- bun install
- bun --filter react test:e2e tests/form.spec.ts
- bun run react:build

@p-sw