### PR TITLE
feat: add Breadcrumb component

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [x] Alert
   - [ ] Avatar
   - [ ] Badge
-  - [ ] Breadcrumb
+  - [x] Breadcrumb
   - [x] Button
   - [x] Card
   - [x] Checkbox

--- a/packages/react/components/Breadcrumb.tsx
+++ b/packages/react/components/Breadcrumb.tsx
@@ -1,0 +1,189 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [breadcrumbVariant, resolveBreadcrumbVariantProps] = vcn({
+  base: "w-full",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbProps
+  extends VariantProps<typeof breadcrumbVariant>,
+    React.ComponentPropsWithoutRef<"nav"> {}
+
+const Breadcrumb = React.forwardRef<HTMLElement, BreadcrumbProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveBreadcrumbVariantProps(props);
+    const { "aria-label": ariaLabel, ...otherPropsExtracted } =
+      otherPropsCompressed;
+
+    return (
+      <nav
+        ref={ref}
+        aria-label={ariaLabel ?? "Breadcrumb"}
+        className={breadcrumbVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+Breadcrumb.displayName = "Breadcrumb";
+
+const [breadcrumbListVariant, resolveBreadcrumbListVariantProps] = vcn({
+  base: "flex flex-wrap items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbListProps
+  extends VariantProps<typeof breadcrumbListVariant>,
+    React.ComponentPropsWithoutRef<"ol"> {}
+
+const BreadcrumbList = React.forwardRef<HTMLOListElement, BreadcrumbListProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveBreadcrumbListVariantProps(props);
+
+    return (
+      <ol
+        ref={ref}
+        className={breadcrumbListVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbList.displayName = "BreadcrumbList";
+
+const [breadcrumbItemVariant, resolveBreadcrumbItemVariantProps] = vcn({
+  base: "inline-flex items-center gap-1.5",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbItemProps
+  extends VariantProps<typeof breadcrumbItemVariant>,
+    React.ComponentPropsWithoutRef<"li"> {}
+
+const BreadcrumbItem = React.forwardRef<HTMLLIElement, BreadcrumbItemProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveBreadcrumbItemVariantProps(props);
+
+    return (
+      <li
+        ref={ref}
+        className={breadcrumbItemVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbItem.displayName = "BreadcrumbItem";
+
+const [breadcrumbLinkVariant, resolveBreadcrumbLinkVariantProps] = vcn({
+  base: "transition-colors hover:text-neutral-950 focus-visible:text-neutral-950 focus-visible:underline focus-visible:outline-none dark:hover:text-neutral-50 dark:focus-visible:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbLinkProps
+  extends VariantProps<typeof breadcrumbLinkVariant>,
+    Omit<React.ComponentPropsWithoutRef<"a">, "className">,
+    AsChild {}
+
+const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveBreadcrumbLinkVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "a";
+
+    return (
+      <Comp
+        ref={ref}
+        className={breadcrumbLinkVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbLink.displayName = "BreadcrumbLink";
+
+const [breadcrumbPageVariant, resolveBreadcrumbPageVariantProps] = vcn({
+  base: "font-medium text-neutral-950 dark:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbPageProps
+  extends VariantProps<typeof breadcrumbPageVariant>,
+    Omit<React.ComponentPropsWithoutRef<"span">, "className">,
+    AsChild {}
+
+const BreadcrumbPage = React.forwardRef<HTMLElement, BreadcrumbPageProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveBreadcrumbPageVariantProps(props);
+    const {
+      asChild,
+      "aria-current": ariaCurrent,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "span";
+
+    return (
+      <Comp
+        ref={ref}
+        aria-current={ariaCurrent ?? "page"}
+        className={breadcrumbPageVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbPage.displayName = "BreadcrumbPage";
+
+const [breadcrumbSeparatorVariant, resolveBreadcrumbSeparatorVariantProps] =
+  vcn({
+    base: "inline-flex items-center text-neutral-400 dark:text-neutral-600",
+    variants: {},
+    defaults: {},
+  });
+
+interface BreadcrumbSeparatorProps
+  extends VariantProps<typeof breadcrumbSeparatorVariant>,
+    Omit<React.ComponentPropsWithoutRef<"li">, "className"> {}
+
+const BreadcrumbSeparator = React.forwardRef<
+  HTMLLIElement,
+  BreadcrumbSeparatorProps
+>((props, ref) => {
+  const [variantProps, otherPropsExtracted] =
+    resolveBreadcrumbSeparatorVariantProps(props);
+
+  return (
+    <li
+      ref={ref}
+      role="presentation"
+      aria-hidden="true"
+      className={breadcrumbSeparatorVariant(variantProps)}
+      {...otherPropsExtracted}
+    >
+      {props.children ?? "/"}
+    </li>
+  );
+});
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+};

--- a/packages/react/tests/breadcrumb.spec.ts
+++ b/packages/react/tests/breadcrumb.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("breadcrumb renders semantic navigation and decorative separators", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("breadcrumb-section");
+  const nav = section.getByRole("navigation", { name: "Breadcrumb" });
+
+  await expect(nav).toBeVisible();
+  await expect(section.getByRole("link", { name: "Home" })).toHaveAttribute(
+    "href",
+    "/",
+  );
+  await expect(section.getByRole("link", { name: "Settings" })).toHaveAttribute(
+    "href",
+    "#settings",
+  );
+  await expect(section.getByTestId("breadcrumb-current-page")).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+
+  const separators = section.getByTestId("breadcrumb-separator");
+  await expect(separators).toHaveCount(2);
+  await expect(separators.first()).toHaveAttribute("role", "presentation");
+  await expect(separators.first()).toHaveAttribute("aria-hidden", "true");
+});

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -1,6 +1,14 @@
 import React from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "../../components/Alert";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "../../components/Breadcrumb";
 import { Button } from "../../components/Button";
 import {
   Card,
@@ -123,6 +131,36 @@ const ButtonShowcase = () => {
         <Button disabled>Disabled action</Button>
         <span data-testid="button-count">{count}</span>
       </div>
+    </Section>
+  );
+};
+
+const BreadcrumbShowcase = () => {
+  return (
+    <Section
+      testId="breadcrumb"
+      title="Breadcrumb"
+      description="Semantic navigation with decorative separators."
+    >
+      <Breadcrumb data-testid="breadcrumb-nav">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="breadcrumb-separator" />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <a href="#settings">Settings</a>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="breadcrumb-separator" />
+          <BreadcrumbItem>
+            <BreadcrumbPage asChild>
+              <span data-testid="breadcrumb-current-page">Profile</span>
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
     </Section>
   );
 };
@@ -447,6 +485,7 @@ const TooltipShowcase = () => {
 const showcases = [
   AlertShowcase,
   ButtonShowcase,
+  BreadcrumbShowcase,
   CardShowcase,
   CheckboxShowcase,
   DialogShowcase,

--- a/registry.json
+++ b/registry.json
@@ -13,6 +13,7 @@
   ],
   "components": {
     "alert": { "type": "file", "name": "Alert.tsx" },
+    "breadcrumb": { "type": "file", "name": "Breadcrumb.tsx" },
     "button": { "type": "file", "name": "Button.tsx" },
     "card": { "type": "file", "name": "Card.tsx" },
     "checkbox": { "type": "file", "name": "Checkbox.tsx" },


### PR DESCRIPTION
## Summary
- add a new `Breadcrumb` component family with semantic navigation, decorative separators, and current-page support
- add a focused Playwright harness showcase and regression coverage for the new component
- register `breadcrumb` in `registry.json` and mark the roadmap item complete in `README.md`

## Validation
- `bun install`
- `bun --filter react test:e2e tests/breadcrumb.spec.ts`
- `bun run react:build`

## Preview
![Breadcrumb preview](https://public.psw.kr/pswui-breadcrumb-pr-28.png)

cc @p-sw
