### PR TITLE
fix: improve toast announcement accessibility

### DIFF
--- a/packages/react/components/Toast/Component.tsx
+++ b/packages/react/components/Toast/Component.tsx
@@ -21,6 +21,26 @@ import {
 } from "./Store";
 import { toastVariant } from "./Variant";
 
+function getToastAnnouncementAttributes(
+  status: (typeof toasts)[`${number}`]["status"],
+) {
+  if (status === "error") {
+    return {
+      role: "alert" as const,
+      "aria-live": "assertive" as const,
+      "aria-atomic": "true" as const,
+      "aria-relevant": "additions text" as const,
+    };
+  }
+
+  return {
+    role: "status" as const,
+    "aria-live": "polite" as const,
+    "aria-atomic": "true" as const,
+    "aria-relevant": "additions text" as const,
+  };
+}
+
 const ToastTemplate = ({
   id,
   globalOption,
@@ -43,6 +63,9 @@ const ToastTemplate = ({
     ...globalOption,
     ...toast,
   };
+  const announcementAttributes = getToastAnnouncementAttributes(
+    toastData.status,
+  );
 
   React.useEffect(() => {
     if (toastData.life === "born") {
@@ -113,8 +136,13 @@ const ToastTemplate = ({
           </svg>
         </button>
       )}
-      <div className="text-sm font-bold">{toastData.title}</div>
-      <div className="text-sm">{toastData.description}</div>
+      <div
+        data-toast-announcement={true}
+        {...announcementAttributes}
+      >
+        <div className="text-sm font-bold">{toastData.title}</div>
+        <div className="text-sm">{toastData.description}</div>
+      </div>
     </div>
   );
 };

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -396,18 +396,32 @@ const ToastTrigger = () => {
   const { toast } = useToast();
 
   return (
-    <Button
-      onClick={() =>
-        toast({
-          title: "Toast title",
-          description: "Toast description",
-          status: "success",
-          closeTimeout: null,
-        })
-      }
-    >
-      Show toast
-    </Button>
+    <div className="flex gap-2">
+      <Button
+        onClick={() =>
+          toast({
+            title: "Toast title",
+            description: "Toast description",
+            status: "success",
+            closeTimeout: null,
+          })
+        }
+      >
+        Show toast
+      </Button>
+      <Button
+        onClick={() =>
+          toast({
+            title: "Error toast title",
+            description: "Error toast description",
+            status: "error",
+            closeTimeout: null,
+          })
+        }
+      >
+        Show error toast
+      </Button>
+    </div>
   );
 };
 

--- a/packages/react/tests/toast.spec.ts
+++ b/packages/react/tests/toast.spec.ts
@@ -2,15 +2,37 @@ import { expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
-test("toast renders and can be dismissed", async ({ page }) => {
+test("toast announces non-error notifications politely and can be dismissed", async ({
+  page,
+}) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("toast-section");
   await section.getByRole("button", { name: "Show toast" }).click();
 
-  await expect(page.getByText("Toast title")).toBeVisible();
-  await expect(page.getByText("Toast description")).toBeVisible();
+  const toast = page.getByRole("status").filter({ hasText: "Toast title" });
+
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText("Toast description");
+  await expect(toast).toHaveAttribute("aria-live", "polite");
+  await expect(toast).toHaveAttribute("aria-atomic", "true");
 
   await page.getByRole("button", { name: "Close" }).click();
-  await expect(page.getByText("Toast title")).not.toBeVisible();
+  await expect(toast).not.toBeVisible();
+});
+
+test("toast announces error notifications assertively", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("toast-section");
+  await section.getByRole("button", { name: "Show error toast" }).click();
+
+  const toast = page
+    .getByRole("alert")
+    .filter({ hasText: "Error toast title" });
+
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText("Error toast description");
+  await expect(toast).toHaveAttribute("aria-live", "assertive");
+  await expect(toast).toHaveAttribute("aria-atomic", "true");
 });


### PR DESCRIPTION
## Summary
- add status-aware live-region semantics to toast message content so screen readers announce toast text without the close button
- keep the change scoped to the existing Toast component and extend the harness with success + error toast triggers
- strengthen the Playwright toast spec to cover polite vs assertive announcements and dismiss behavior

## Testing
- bun install
- bun --filter react test:e2e tests/toast.spec.ts
- bun run react:build
- git push (pre-push ran biome_check and react_tsc)

@p-sw please review.