### PR TITLE
feat: add Accordion component

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] ImageInput
   - [ ] Form
   - [ ] Textarea
-  - [ ] Accordion
+  - [x] Accordion
   - [x] Alert
   - [ ] Avatar
   - [ ] Badge

--- a/packages/react/components/Accordion/Component.tsx
+++ b/packages/react/components/Accordion/Component.tsx
@@ -1,0 +1,226 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+import {
+  AccordionContext,
+  AccordionItemContext,
+  useAccordionContext,
+  useAccordionItemContext,
+} from "./Context";
+
+const [accordionVariant, resolveAccordionVariantProps] = vcn({
+  base: "overflow-hidden rounded-lg border border-neutral-200 bg-white text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-black dark:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface AccordionProps
+  extends VariantProps<typeof accordionVariant>,
+    React.ComponentPropsWithoutRef<"div"> {
+  defaultValue?: string;
+  value?: string | null;
+  onValueChange?: (value: string | null) => void;
+  collapsible?: boolean;
+}
+
+const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveAccordionVariantProps(props);
+    const {
+      defaultValue,
+      value,
+      onValueChange,
+      collapsible = false,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const [internalValue, setInternalValue] = React.useState<string | null>(
+      defaultValue ?? null,
+    );
+
+    const currentValue = value !== undefined ? value : internalValue;
+
+    function onItemToggle(nextValue: string) {
+      const resolvedValue =
+        currentValue === nextValue
+          ? collapsible
+            ? null
+            : nextValue
+          : nextValue;
+
+      if (value === undefined) {
+        setInternalValue(resolvedValue);
+      }
+
+      onValueChange?.(resolvedValue);
+    }
+
+    return (
+      <AccordionContext.Provider
+        value={{
+          value: currentValue,
+          collapsible,
+          onItemToggle,
+        }}
+      >
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          className={accordionVariant(variantProps)}
+        />
+      </AccordionContext.Provider>
+    );
+  },
+);
+Accordion.displayName = "Accordion";
+
+const [accordionItemVariant, resolveAccordionItemVariantProps] = vcn({
+  base: "overflow-hidden border-b border-neutral-200 last:border-b-0 dark:border-neutral-800",
+  variants: {},
+  defaults: {},
+});
+
+interface AccordionItemProps
+  extends VariantProps<typeof accordionItemVariant>,
+    React.ComponentPropsWithoutRef<"div"> {
+  value: string;
+  disabled?: boolean;
+}
+
+const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveAccordionItemVariantProps(props);
+    const {
+      value,
+      disabled = false,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const { value: activeValue, onItemToggle } = useAccordionContext();
+    const triggerId = React.useId();
+    const contentId = React.useId();
+    const open = activeValue === value;
+
+    return (
+      <AccordionItemContext.Provider
+        value={{
+          value,
+          open,
+          disabled,
+          triggerId,
+          contentId,
+          onToggle: () => {
+            if (disabled) {
+              return;
+            }
+
+            onItemToggle(value);
+          },
+        }}
+      >
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          data-disabled={disabled ? "" : undefined}
+          data-state={open ? "open" : "closed"}
+          className={accordionItemVariant(variantProps)}
+        />
+      </AccordionItemContext.Provider>
+    );
+  },
+);
+AccordionItem.displayName = "AccordionItem";
+
+const [accordionTriggerVariant, resolveAccordionTriggerVariantProps] = vcn({
+  base: "flex w-full items-center justify-between gap-4 px-4 py-3 text-left text-sm font-medium transition-colors outline outline-1 outline-transparent outline-offset-2 hover:bg-neutral-50 focus-visible:outline-black/10 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-neutral-950 dark:focus-visible:outline-white/20",
+  variants: {
+    open: {
+      true: "bg-neutral-50 dark:bg-neutral-950",
+      false: "",
+    },
+  },
+  defaults: {
+    open: false,
+  },
+});
+
+interface AccordionTriggerProps
+  extends Omit<VariantProps<typeof accordionTriggerVariant>, "open">,
+    Omit<React.ComponentPropsWithoutRef<"button">, "type"> {}
+
+const AccordionTrigger = React.forwardRef<
+  HTMLButtonElement,
+  AccordionTriggerProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveAccordionTriggerVariantProps(props);
+  const { onClick, children, ...otherPropsExtracted } = otherPropsCompressed;
+  const { open, disabled, triggerId, contentId, onToggle } =
+    useAccordionItemContext();
+
+  return (
+    <h3 className="flex">
+      <button
+        {...otherPropsExtracted}
+        ref={ref}
+        id={triggerId}
+        type="button"
+        disabled={disabled}
+        aria-controls={contentId}
+        aria-expanded={open}
+        className={accordionTriggerVariant({
+          ...variantProps,
+          open,
+        })}
+        onClick={(event) => {
+          onToggle();
+          onClick?.(event);
+        }}
+      >
+        <span>{children}</span>
+        <span
+          aria-hidden="true"
+          className="text-lg leading-none"
+        >
+          {open ? "-" : "+"}
+        </span>
+      </button>
+    </h3>
+  );
+});
+AccordionTrigger.displayName = "AccordionTrigger";
+
+const [accordionContentVariant, resolveAccordionContentVariantProps] = vcn({
+  base: "px-4 pb-4 text-sm text-neutral-600 dark:text-neutral-300",
+  variants: {},
+  defaults: {},
+});
+
+interface AccordionContentProps
+  extends VariantProps<typeof accordionContentVariant>,
+    React.ComponentPropsWithoutRef<"div"> {}
+
+const AccordionContent = React.forwardRef<
+  HTMLDivElement,
+  AccordionContentProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveAccordionContentVariantProps(props);
+  const { open, triggerId, contentId } = useAccordionItemContext();
+
+  return (
+    <div
+      {...otherPropsCompressed}
+      ref={ref}
+      id={contentId}
+      role="region"
+      aria-labelledby={triggerId}
+      hidden={!open}
+      data-state={open ? "open" : "closed"}
+      className={accordionContentVariant(variantProps)}
+    />
+  );
+});
+AccordionContent.displayName = "AccordionContent";
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/packages/react/components/Accordion/Context.ts
+++ b/packages/react/components/Accordion/Context.ts
@@ -1,0 +1,55 @@
+import { createContext, useContext } from "react";
+
+export interface IAccordionContext {
+  value: string | null;
+  collapsible: boolean;
+  onItemToggle: (value: string) => void;
+}
+
+export const initialAccordionContext: IAccordionContext = {
+  value: null,
+  collapsible: false,
+  onItemToggle: () => {
+    if (process.env.NODE_ENV && process.env.NODE_ENV === "development") {
+      console.warn(
+        "It seems like you're using AccordionContext outside of a provider.",
+      );
+    }
+  },
+};
+
+export const AccordionContext = createContext<IAccordionContext>(
+  initialAccordionContext,
+);
+
+export const useAccordionContext = () => useContext(AccordionContext);
+
+export interface IAccordionItemContext {
+  value: string;
+  open: boolean;
+  disabled: boolean;
+  triggerId: string;
+  contentId: string;
+  onToggle: () => void;
+}
+
+export const initialAccordionItemContext: IAccordionItemContext = {
+  value: "",
+  open: false,
+  disabled: false,
+  triggerId: "",
+  contentId: "",
+  onToggle: () => {
+    if (process.env.NODE_ENV && process.env.NODE_ENV === "development") {
+      console.warn(
+        "It seems like you're using AccordionItemContext outside of a provider.",
+      );
+    }
+  },
+};
+
+export const AccordionItemContext = createContext<IAccordionItemContext>(
+  initialAccordionItemContext,
+);
+
+export const useAccordionItemContext = () => useContext(AccordionItemContext);

--- a/packages/react/components/Accordion/index.ts
+++ b/packages/react/components/Accordion/index.ts
@@ -1,0 +1,2 @@
+export * from "./Component";
+export * from "./Context";

--- a/packages/react/tests/accordion.spec.ts
+++ b/packages/react/tests/accordion.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("accordion opens one item at a time and supports collapsing", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("accordion-section");
+  const shippingTrigger = section.getByRole("button", { name: "Shipping" });
+  const returnsTrigger = section.getByRole("button", { name: "Returns" });
+
+  await expect(shippingTrigger).toHaveAttribute("aria-expanded", "true");
+  await expect(returnsTrigger).toHaveAttribute("aria-expanded", "false");
+  await expect(section.getByRole("region", { name: "Shipping" })).toBeVisible();
+  await expect(section.getByRole("region", { name: "Returns" })).toHaveCount(0);
+
+  await returnsTrigger.click();
+
+  await expect(shippingTrigger).toHaveAttribute("aria-expanded", "false");
+  await expect(returnsTrigger).toHaveAttribute("aria-expanded", "true");
+  await expect(section.getByRole("region", { name: "Shipping" })).toHaveCount(
+    0,
+  );
+  await expect(section.getByRole("region", { name: "Returns" })).toBeVisible();
+
+  await returnsTrigger.click();
+
+  await expect(returnsTrigger).toHaveAttribute("aria-expanded", "false");
+  await expect(section.getByRole("region", { name: "Returns" })).toHaveCount(0);
+});

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -1,5 +1,11 @@
 import React from "react";
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../../components/Accordion";
 import { Alert, AlertDescription, AlertTitle } from "../../components/Alert";
 import { Button } from "../../components/Button";
 import {
@@ -105,6 +111,34 @@ const AlertShowcase = () => {
           </AlertDescription>
         </Alert>
       </div>
+    </Section>
+  );
+};
+
+const AccordionShowcase = () => {
+  return (
+    <Section
+      testId="accordion"
+      title="Accordion"
+      description="Single-open accordion with collapsible sections."
+    >
+      <Accordion
+        defaultValue="shipping"
+        collapsible
+      >
+        <AccordionItem value="shipping">
+          <AccordionTrigger>Shipping</AccordionTrigger>
+          <AccordionContent>
+            Ships within 2 to 3 business days for in-stock items.
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="returns">
+          <AccordionTrigger>Returns</AccordionTrigger>
+          <AccordionContent>
+            Returns are accepted within 30 days of delivery.
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </Section>
   );
 };
@@ -445,6 +479,7 @@ const TooltipShowcase = () => {
 };
 
 const showcases = [
+  AccordionShowcase,
   AlertShowcase,
   ButtonShowcase,
   CardShowcase,

--- a/registry.json
+++ b/registry.json
@@ -12,6 +12,11 @@
     "useAnimatedMount.ts"
   ],
   "components": {
+    "accordion": {
+      "type": "dir",
+      "name": "Accordion",
+      "files": ["index.ts", "Context.ts", "Component.tsx"]
+    },
     "alert": { "type": "file", "name": "Alert.tsx" },
     "button": { "type": "file", "name": "Button.tsx" },
     "card": { "type": "file", "name": "Card.tsx" },


### PR DESCRIPTION
## Summary
- add a new Accordion component family with accessible trigger/content relationships and single-open collapsible behavior
- add a focused Playwright harness showcase and regression coverage for accordion toggle behavior
- register the Accordion component and mark the roadmap item complete in the README

## Testing
- bun install
- bun --filter react test:e2e tests/accordion.spec.ts
- bun run react:build

## Preview
![Accordion component preview](https://public.psw.kr/pswui-accordion-pr-30.png)

cc @p-sw
