### PR TITLE
feat: add Table component

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] Skeleton
   - [ ] Slider
   - [x] Switch
-  - [ ] Table
+  - [x] Table
   - [x] Tabs
   - [x] Toast
   - [ ] Toggle

--- a/packages/react/components/Table.tsx
+++ b/packages/react/components/Table.tsx
@@ -1,0 +1,219 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [tableVariant, resolveTableVariantProps] = vcn({
+  base: "w-full caption-bottom text-sm",
+  variants: {},
+  defaults: {},
+});
+
+interface TableProps
+  extends VariantProps<typeof tableVariant>,
+    React.ComponentPropsWithoutRef<"table"> {}
+
+const Table = React.forwardRef<HTMLTableElement, TableProps>((props, ref) => {
+  const [variantProps, otherPropsExtracted] = resolveTableVariantProps(props);
+
+  return (
+    <table
+      ref={ref}
+      className={tableVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+Table.displayName = "Table";
+
+const [tableHeaderVariant, resolveTableHeaderVariantProps] = vcn({
+  base: "[&_tr]:border-b [&_tr]:border-neutral-200 dark:[&_tr]:border-neutral-800",
+  variants: {},
+  defaults: {},
+});
+
+interface TableHeaderProps
+  extends VariantProps<typeof tableHeaderVariant>,
+    React.ComponentPropsWithoutRef<"thead"> {}
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, TableHeaderProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableHeaderVariantProps(props);
+
+    return (
+      <thead
+        ref={ref}
+        className={tableHeaderVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableHeader.displayName = "TableHeader";
+
+const [tableBodyVariant, resolveTableBodyVariantProps] = vcn({
+  base: "[&_tr:last-child]:border-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableBodyProps
+  extends VariantProps<typeof tableBodyVariant>,
+    React.ComponentPropsWithoutRef<"tbody"> {}
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableBodyVariantProps(props);
+
+    return (
+      <tbody
+        ref={ref}
+        className={tableBodyVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableBody.displayName = "TableBody";
+
+const [tableFooterVariant, resolveTableFooterVariantProps] = vcn({
+  base: "border-t border-neutral-200 bg-neutral-50/50 font-medium dark:border-neutral-800 dark:bg-neutral-950/50 [&>tr]:last:border-b-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableFooterProps
+  extends VariantProps<typeof tableFooterVariant>,
+    React.ComponentPropsWithoutRef<"tfoot"> {}
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, TableFooterProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableFooterVariantProps(props);
+
+    return (
+      <tfoot
+        ref={ref}
+        className={tableFooterVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableFooter.displayName = "TableFooter";
+
+const [tableRowVariant, resolveTableRowVariantProps] = vcn({
+  base: "border-b border-neutral-200 transition-colors hover:bg-neutral-50/50 data-[state=selected]:bg-neutral-100 dark:border-neutral-800 dark:hover:bg-neutral-900/50 dark:data-[state=selected]:bg-neutral-900",
+  variants: {},
+  defaults: {},
+});
+
+interface TableRowProps
+  extends VariantProps<typeof tableRowVariant>,
+    React.ComponentPropsWithoutRef<"tr"> {}
+
+const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableRowVariantProps(props);
+
+    return (
+      <tr
+        ref={ref}
+        className={tableRowVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableRow.displayName = "TableRow";
+
+const [tableHeadVariant, resolveTableHeadVariantProps] = vcn({
+  base: "h-10 px-4 text-left align-middle font-medium text-neutral-500 dark:text-neutral-400 [&:has([role=checkbox])]:pr-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableHeadProps
+  extends VariantProps<typeof tableHeadVariant>,
+    React.ComponentPropsWithoutRef<"th"> {}
+
+const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableHeadVariantProps(props);
+
+    return (
+      <th
+        ref={ref}
+        className={tableHeadVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableHead.displayName = "TableHead";
+
+const [tableCellVariant, resolveTableCellVariantProps] = vcn({
+  base: "p-4 align-middle [&:has([role=checkbox])]:pr-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableCellProps
+  extends VariantProps<typeof tableCellVariant>,
+    React.ComponentPropsWithoutRef<"td"> {}
+
+const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableCellVariantProps(props);
+
+    return (
+      <td
+        ref={ref}
+        className={tableCellVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableCell.displayName = "TableCell";
+
+const [tableCaptionVariant, resolveTableCaptionVariantProps] = vcn({
+  base: "mt-4 text-sm text-neutral-500 dark:text-neutral-400",
+  variants: {},
+  defaults: {},
+});
+
+interface TableCaptionProps
+  extends VariantProps<typeof tableCaptionVariant>,
+    React.ComponentPropsWithoutRef<"caption"> {}
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  TableCaptionProps
+>((props, ref) => {
+  const [variantProps, otherPropsExtracted] =
+    resolveTableCaptionVariantProps(props);
+
+  return (
+    <caption
+      ref={ref}
+      className={tableCaptionVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -48,6 +48,16 @@ import {
 import { Separator } from "../../components/Separator";
 import { Switch } from "../../components/Switch";
 import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../components/Table";
+import {
   TabContent,
   TabList,
   TabProvider,
@@ -367,6 +377,54 @@ const SwitchShowcase = () => {
   );
 };
 
+const TableShowcase = () => {
+  return (
+    <Section
+      testId="table"
+      title="Table"
+      description="Semantic table structure with header, body, footer, and caption."
+    >
+      <div className="overflow-x-auto">
+        <Table data-testid="table-root">
+          <TableCaption data-testid="table-caption">
+            Quarterly revenue by team
+          </TableCaption>
+          <TableHeader data-testid="table-header">
+            <TableRow>
+              <TableHead scope="col">Team</TableHead>
+              <TableHead scope="col">Region</TableHead>
+              <TableHead
+                scope="col"
+                className="text-right"
+              >
+                Revenue
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody data-testid="table-body">
+            <TableRow>
+              <TableCell>Platform</TableCell>
+              <TableCell>North America</TableCell>
+              <TableCell className="text-right">$92K</TableCell>
+            </TableRow>
+            <TableRow data-state="selected">
+              <TableCell>Infrastructure</TableCell>
+              <TableCell>Europe</TableCell>
+              <TableCell className="text-right">$74K</TableCell>
+            </TableRow>
+          </TableBody>
+          <TableFooter data-testid="table-footer">
+            <TableRow>
+              <TableCell colSpan={2}>Total</TableCell>
+              <TableCell className="text-right">$166K</TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </div>
+    </Section>
+  );
+};
+
 const TabsShowcase = () => {
   return (
     <Section
@@ -457,6 +515,7 @@ const showcases = [
   PopoverShowcase,
   SeparatorShowcase,
   SwitchShowcase,
+  TableShowcase,
   TabsShowcase,
   ToastShowcase,
   TooltipShowcase,

--- a/packages/react/tests/table.spec.ts
+++ b/packages/react/tests/table.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("table renders semantic sections, headers, cells, and caption", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("table-section");
+  const table = section.getByRole("table", {
+    name: "Quarterly revenue by team",
+  });
+
+  await expect(table).toHaveJSProperty("tagName", "TABLE");
+  await expect(section.getByTestId("table-caption")).toHaveJSProperty(
+    "tagName",
+    "CAPTION",
+  );
+  await expect(section.getByTestId("table-header")).toHaveJSProperty(
+    "tagName",
+    "THEAD",
+  );
+  await expect(section.getByTestId("table-body")).toHaveJSProperty(
+    "tagName",
+    "TBODY",
+  );
+  await expect(section.getByTestId("table-footer")).toHaveJSProperty(
+    "tagName",
+    "TFOOT",
+  );
+
+  await expect(section.getByRole("rowgroup")).toHaveCount(3);
+  await expect(
+    section.getByRole("columnheader", { name: "Team" }),
+  ).toBeVisible();
+  await expect(
+    section.getByRole("columnheader", { name: "Region" }),
+  ).toBeVisible();
+  await expect(
+    section.getByRole("columnheader", { name: "Revenue" }),
+  ).toBeVisible();
+  await expect(section.getByRole("cell", { name: "$92K" })).toBeVisible();
+  await expect(section.getByRole("cell", { name: "$74K" })).toBeVisible();
+  await expect(section.getByRole("cell", { name: "$166K" })).toBeVisible();
+  await expect(section.getByRole("row")).toHaveCount(4);
+});

--- a/registry.json
+++ b/registry.json
@@ -28,6 +28,7 @@
     "popover": { "type": "file", "name": "Popover.tsx" },
     "separator": { "type": "file", "name": "Separator.tsx" },
     "switch": { "type": "file", "name": "Switch.tsx" },
+    "table": { "type": "file", "name": "Table.tsx" },
     "tabs": {
       "type": "dir",
       "name": "Tabs",


### PR DESCRIPTION
## Summary
- add a new Table component family with semantic table structure helpers for header, body, footer, rows, cells, and caption
- add a focused Playwright harness showcase and regression coverage for semantic table rendering
- register `table` in `registry.json` and mark the roadmap item complete in `README.md`

## Validation
- bun install
- bun --filter react test:e2e tests/table.spec.ts
- bun run react:build

## Screenshot
![Table component screenshot](https://public.psw.kr/pswui-table-pr-32.png)

cc @p-sw