### PR TITLE
fix(label): preserve custom className with variants

### DIFF
--- a/packages/react/components/Label.tsx
+++ b/packages/react/components/Label.tsx
@@ -19,13 +19,14 @@ interface LabelProps
     React.ComponentPropsWithoutRef<"label"> {}
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>((props, ref) => {
+  const { className } = props;
   const [variantProps, otherPropsCompressed] = resolveLabelVariantProps(props);
 
   return (
     <label
       ref={ref}
       {...otherPropsCompressed}
-      className={labelVariant(variantProps)}
+      className={labelVariant({ ...variantProps, className })}
     />
   );
 });

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -283,6 +283,7 @@ const LabelShowcase = () => {
     >
       <Label
         direction="horizontal"
+        className="bg-amber-100"
         data-testid="label-control"
       >
         <input

--- a/packages/react/tests/label.spec.ts
+++ b/packages/react/tests/label.spec.ts
@@ -2,6 +2,17 @@ import { expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
+test("label preserves custom className with variant classes", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const label = page.getByTestId("label-control");
+
+  await expect(label).toHaveClass(/bg-amber-100/);
+  await expect(label).toHaveClass(/flex-row/);
+});
+
 test("label click toggles nested checkbox", async ({ page }) => {
   await gotoHarness(page);
 


### PR DESCRIPTION
Summary
- preserve custom `Label` classes when variant classes are applied
- extend the existing Label harness/example to include a custom class regression case
- strengthen the existing Playwright spec to verify both custom and variant classes while keeping click-to-toggle coverage

Validation
- bun install
- bun --filter react test:e2e tests/label.spec.ts
- bun run react:build

@p-sw please review when you have a moment.