### PR TITLE
feat: add Pagination component

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [x] Label
   - [ ] Menubar
   - [ ] Navigation Menu
-  - [ ] Pagination
+  - [x] Pagination
   - [x] Popover
   - [ ] Progress
   - [ ] Radio Group

--- a/packages/react/components/Pagination.tsx
+++ b/packages/react/components/Pagination.tsx
@@ -1,0 +1,241 @@
+import { type AsChild, Slot, vcn } from "@pswui-lib";
+import React from "react";
+
+const paginationColors = {
+  border: "border-neutral-300 dark:border-neutral-700",
+  background: {
+    default: "bg-white dark:bg-black",
+    hover: "hover:bg-neutral-100 dark:hover:bg-neutral-900",
+    active:
+      "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900",
+  },
+  text: "text-neutral-700 dark:text-neutral-200",
+  muted: "text-neutral-500 dark:text-neutral-400",
+  outline: "focus-visible:outline-black/10 dark:focus-visible:outline-white/20",
+};
+
+const [paginationLinkVariants] = vcn({
+  base: `inline-flex min-h-9 min-w-9 items-center justify-center gap-1 rounded-md border px-3 text-sm font-medium outline outline-1 outline-transparent outline-offset-2 transition-colors ${paginationColors.outline}`,
+  variants: {
+    current: {
+      true: `border-transparent ${paginationColors.background.active}`,
+      false: `${paginationColors.border} ${paginationColors.background.default} ${paginationColors.background.hover} ${paginationColors.text}`,
+    },
+    disabledStyle: {
+      true: "cursor-not-allowed opacity-50",
+      false: "cursor-pointer",
+    },
+  },
+  defaults: {
+    current: false,
+    disabledStyle: false,
+  },
+});
+
+interface PaginationProps
+  extends React.ComponentPropsWithoutRef<"nav">,
+    AsChild {}
+
+const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
+  (props, ref) => {
+    const {
+      asChild,
+      className,
+      "aria-label": ariaLabel,
+      ...otherProps
+    } = props;
+    const Comp = asChild ? Slot : "nav";
+
+    return (
+      <Comp
+        ref={ref}
+        aria-label={ariaLabel ?? "Pagination"}
+        className={`flex w-full justify-center ${className ?? ""}`.trim()}
+        {...otherProps}
+      />
+    );
+  },
+);
+Pagination.displayName = "Pagination";
+
+interface PaginationContentProps
+  extends React.ComponentPropsWithoutRef<"ul">,
+    AsChild {}
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  PaginationContentProps
+>((props, ref) => {
+  const { asChild, className, ...otherProps } = props;
+  const Comp = asChild ? Slot : "ul";
+
+  return (
+    <Comp
+      ref={ref}
+      className={`m-0 flex flex-wrap items-center gap-1 p-0 list-none ${className ?? ""}`.trim()}
+      {...otherProps}
+    />
+  );
+});
+PaginationContent.displayName = "PaginationContent";
+
+interface PaginationItemProps
+  extends React.ComponentPropsWithoutRef<"li">,
+    AsChild {}
+
+const PaginationItem = React.forwardRef<HTMLLIElement, PaginationItemProps>(
+  (props, ref) => {
+    const { asChild, className, ...otherProps } = props;
+    const Comp = asChild ? Slot : "li";
+
+    return (
+      <Comp
+        ref={ref}
+        className={className}
+        {...otherProps}
+      />
+    );
+  },
+);
+PaginationItem.displayName = "PaginationItem";
+
+interface PaginationLinkProps
+  extends React.ComponentPropsWithoutRef<"a">,
+    AsChild {
+  active?: boolean;
+  disabled?: boolean;
+}
+
+const PaginationLink = React.forwardRef<HTMLAnchorElement, PaginationLinkProps>(
+  (props, ref) => {
+    const {
+      asChild,
+      children,
+      className,
+      active,
+      disabled,
+      href,
+      onClick,
+      role,
+      tabIndex,
+      "aria-current": ariaCurrent,
+      "aria-disabled": ariaDisabled,
+      ...otherProps
+    } = props;
+    const Comp = asChild ? Slot : "a";
+
+    return (
+      <Comp
+        ref={ref}
+        href={disabled ? undefined : href}
+        role={role ?? "link"}
+        aria-current={active ? ariaCurrent ?? "page" : ariaCurrent}
+        aria-disabled={disabled ? true : ariaDisabled}
+        tabIndex={disabled ? -1 : tabIndex}
+        className={paginationLinkVariants({
+          current: active,
+          disabledStyle: disabled,
+          className,
+        })}
+        onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+          if (disabled) {
+            event.preventDefault();
+            return;
+          }
+
+          onClick?.(event);
+        }}
+        {...otherProps}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+PaginationLink.displayName = "PaginationLink";
+
+interface PaginationPreviousProps
+  extends Omit<PaginationLinkProps, "children"> {
+  children?: React.ReactNode;
+}
+
+const PaginationPrevious = React.forwardRef<
+  HTMLAnchorElement,
+  PaginationPreviousProps
+>((props, ref) => {
+  const { children, "aria-label": ariaLabel, ...otherProps } = props;
+
+  return (
+    <PaginationLink
+      ref={ref}
+      aria-label={ariaLabel ?? "Previous page"}
+      {...otherProps}
+    >
+      <span aria-hidden="true">&lt;</span>
+      <span>{children ?? "Previous"}</span>
+    </PaginationLink>
+  );
+});
+PaginationPrevious.displayName = "PaginationPrevious";
+
+interface PaginationNextProps extends Omit<PaginationLinkProps, "children"> {
+  children?: React.ReactNode;
+}
+
+const PaginationNext = React.forwardRef<HTMLAnchorElement, PaginationNextProps>(
+  (props, ref) => {
+    const { children, "aria-label": ariaLabel, ...otherProps } = props;
+
+    return (
+      <PaginationLink
+        ref={ref}
+        aria-label={ariaLabel ?? "Next page"}
+        {...otherProps}
+      >
+        <span>{children ?? "Next"}</span>
+        <span aria-hidden="true">&gt;</span>
+      </PaginationLink>
+    );
+  },
+);
+PaginationNext.displayName = "PaginationNext";
+
+interface PaginationEllipsisProps
+  extends React.ComponentPropsWithoutRef<"span">,
+    AsChild {}
+
+const PaginationEllipsis = React.forwardRef<
+  HTMLSpanElement,
+  PaginationEllipsisProps
+>((props, ref) => {
+  const {
+    asChild,
+    className,
+    "aria-hidden": ariaHidden,
+    children,
+    ...otherProps
+  } = props;
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      ref={ref}
+      aria-hidden={ariaHidden ?? true}
+      className={`inline-flex min-h-9 min-w-9 items-center justify-center text-sm ${paginationColors.muted} ${className ?? ""}`.trim()}
+      {...otherProps}
+    >
+      {children ?? "..."}
+    </Comp>
+  );
+});
+PaginationEllipsis.displayName = "PaginationEllipsis";
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -41,6 +41,15 @@ import {
 import { Input, InputFrame } from "../../components/Input";
 import { Label } from "../../components/Label";
 import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "../../components/Pagination";
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -295,6 +304,76 @@ const LabelShowcase = () => {
   );
 };
 
+const PaginationShowcase = () => {
+  const [lastAction, setLastAction] = React.useState("page:1");
+
+  return (
+    <Section
+      testId="pagination"
+      title="Pagination"
+      description="Semantic pagination with current, disabled, and ellipsis states."
+    >
+      <div className="flex flex-col gap-4">
+        <Pagination aria-label="Results pages">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#page-0"
+                disabled
+                onClick={() => setLastAction("previous")}
+              />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink
+                href="#page-1"
+                active
+                onClick={(event) => event.preventDefault()}
+              >
+                1
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink
+                href="#page-2"
+                onClick={(event) => {
+                  event.preventDefault();
+                  setLastAction("page:2");
+                }}
+              >
+                2
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationEllipsis data-testid="pagination-ellipsis" />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink
+                href="#page-8"
+                onClick={(event) => {
+                  event.preventDefault();
+                  setLastAction("page:8");
+                }}
+              >
+                8
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext
+                href="#page-2"
+                onClick={(event) => {
+                  event.preventDefault();
+                  setLastAction("next");
+                }}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+        <p data-testid="pagination-last-action">{lastAction}</p>
+      </div>
+    </Section>
+  );
+};
+
 const PopoverShowcase = () => {
   return (
     <Section
@@ -454,6 +533,7 @@ const showcases = [
   FormShowcase,
   InputShowcase,
   LabelShowcase,
+  PaginationShowcase,
   PopoverShowcase,
   SeparatorShowcase,
   SwitchShowcase,

--- a/packages/react/tests/pagination.spec.ts
+++ b/packages/react/tests/pagination.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("pagination exposes accessible navigation semantics and skips disabled actions", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("pagination-section");
+  const navigation = section.getByRole("navigation", { name: "Results pages" });
+
+  await expect(navigation).toBeVisible();
+  await expect(navigation.locator('[aria-current="page"]')).toHaveText("1");
+  await expect(navigation.getByRole("link")).toHaveCount(5);
+
+  const previous = navigation.getByRole("link", { name: "Previous page" });
+  await expect(previous).toHaveAttribute("aria-disabled", "true");
+  await expect(previous).toHaveAttribute("tabindex", "-1");
+
+  await previous.click({ force: true });
+  await expect(section.getByTestId("pagination-last-action")).toHaveText(
+    "page:1",
+  );
+
+  const ellipsis = section.getByTestId("pagination-ellipsis");
+  await expect(ellipsis).toHaveAttribute("aria-hidden", "true");
+
+  await navigation.getByRole("link", { name: "2" }).click();
+  await expect(section.getByTestId("pagination-last-action")).toHaveText(
+    "page:2",
+  );
+});

--- a/registry.json
+++ b/registry.json
@@ -25,6 +25,7 @@
     "form": { "type": "file", "name": "Form.tsx" },
     "input": { "type": "file", "name": "Input.tsx" },
     "label": { "type": "file", "name": "Label.tsx" },
+    "pagination": { "type": "file", "name": "Pagination.tsx" },
     "popover": { "type": "file", "name": "Popover.tsx" },
     "separator": { "type": "file", "name": "Separator.tsx" },
     "switch": { "type": "file", "name": "Switch.tsx" },


### PR DESCRIPTION
Summary
- add a new Pagination component family with semantic navigation, current-page state, disabled previous/next links, and ellipsis support
- add a focused Playwright harness showcase and regression coverage for the new component
- register pagination in the component registry and mark the roadmap item complete

Tests
- bun install
- bun --filter react test:e2e tests/pagination.spec.ts
- bun run react:build

Screenshot
![Pagination component screenshot](https://public.psw.kr/pswui-pagination-pr-34.png)

@p-sw please take a look.
