### PR TITLE
fix(input): expose invalid state semantically

### DIFF
--- a/packages/react/components/Input.tsx
+++ b/packages/react/components/Input.tsx
@@ -92,7 +92,14 @@ interface InputProps
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const [variantProps, otherPropsCompressed] = resolveInputVariantProps(props);
-  const { type, invalid, ...otherPropsExtracted } = otherPropsCompressed;
+  const {
+    type,
+    invalid,
+    "aria-invalid": ariaInvalid,
+    ...otherPropsExtracted
+  } = otherPropsCompressed;
+  const isInvalid = Boolean(invalid);
+  const resolvedAriaInvalid = isInvalid ? true : ariaInvalid;
 
   const innerRef = React.useRef<HTMLInputElement | null>(null);
 
@@ -105,6 +112,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return (
     <input
       type={type}
+      aria-invalid={resolvedAriaInvalid}
       ref={(el) => {
         innerRef.current = el;
         if (typeof ref === "function") {

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -261,7 +261,7 @@ const InputShowcase = () => {
     <Section
       testId="input"
       title="Input"
-      description="Standalone input with custom validity."
+      description="Standalone input exposing semantic invalid state and custom validity."
     >
       <InputFrame>
         <Input

--- a/packages/react/tests/input.spec.ts
+++ b/packages/react/tests/input.spec.ts
@@ -2,20 +2,26 @@ import { expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
-test("input applies custom validity message", async ({ page }) => {
+test("input exposes semantic invalid state and custom validity message", async ({
+  page,
+}) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("input-section");
   const input = section.getByLabel("Email input");
 
+  await expect(input).toHaveAttribute("aria-invalid", "true");
+
   const validation = await input.evaluate((element) => {
     const target = element as HTMLInputElement;
     return {
       customError: target.validity.customError,
+      valid: target.validity.valid,
       message: target.validationMessage,
     };
   });
 
   expect(validation.customError).toBe(true);
+  expect(validation.valid).toBe(false);
   expect(validation.message).toContain("Invalid email");
 });


### PR DESCRIPTION
## Summary\n- expose the existing Input invalid state with aria-invalid while preserving custom validity handling\n- update the Input harness copy to reflect the accessibility regression being covered\n- strengthen the Playwright Input test to assert both semantic invalid state and the custom validity message\n\n## Validation\n- bun install\n- bun --filter react test:e2e tests/input.spec.ts\n- bun run react:build\n\ncc @p-sw