### PR TITLE
feat: add Radio Group component

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [x] Pagination
   - [x] Popover
   - [x] Progress
-  - [ ] Radio Group
+  - [x] Radio Group
   - [ ] Scroll Area
   - [ ] Select
   - [x] Separator

--- a/packages/react/components/RadioGroup.tsx
+++ b/packages/react/components/RadioGroup.tsx
@@ -1,0 +1,162 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [radioGroupVariant, resolveRadioGroupVariantProps] = vcn({
+  base: "flex",
+  variants: {
+    orientation: {
+      vertical: "flex-col items-start gap-3",
+      horizontal: "flex-row flex-wrap items-center gap-4",
+    },
+  },
+  defaults: {
+    orientation: "vertical",
+  },
+});
+
+const [radioGroupItemVariant, resolveRadioGroupItemVariantProps] = vcn({
+  base: "relative inline-flex w-fit items-center gap-3 rounded-md text-sm outline outline-2 outline-offset-2 outline-transparent transition-colors duration-150 has-[input:focus-visible]:outline-black/10 dark:has-[input:focus-visible]:outline-white/20 has-[input:disabled]:cursor-not-allowed has-[input:disabled]:opacity-60",
+  variants: {},
+  defaults: {},
+});
+
+interface RadioGroupContextValue {
+  disabled?: boolean;
+  name: string;
+  setValue: (value: string) => void;
+  value?: string;
+}
+
+const RadioGroupContext = React.createContext<RadioGroupContextValue | null>(
+  null,
+);
+
+const useRadioGroupContext = () => {
+  const context = React.useContext(RadioGroupContext);
+
+  if (!context) {
+    throw new Error("RadioGroupItem must be used within RadioGroup.");
+  }
+
+  return context;
+};
+
+interface RadioGroupProps
+  extends VariantProps<typeof radioGroupVariant>,
+    Omit<
+      React.ComponentPropsWithoutRef<"div">,
+      "children" | "className" | "defaultValue" | "onChange"
+    > {
+  children?: React.ReactNode;
+  defaultValue?: string;
+  disabled?: boolean;
+  name?: string;
+  onValueChange?: (value: string) => void;
+  value?: string;
+}
+
+const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveRadioGroupVariantProps(props);
+    const {
+      children,
+      defaultValue,
+      disabled,
+      name,
+      onValueChange,
+      value: propValue,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const generatedName = React.useId();
+    const resolvedName = name ?? generatedName;
+    const [uncontrolledValue, setUncontrolledValue] =
+      React.useState(defaultValue);
+    const isControlled = typeof propValue === "string";
+    const value = isControlled ? propValue : uncontrolledValue;
+
+    const orientation = variantProps.orientation ?? "vertical";
+    const contextValue = {
+      disabled,
+      name: resolvedName,
+      setValue: (nextValue: string) => {
+        if (!isControlled) {
+          setUncontrolledValue(nextValue);
+        }
+
+        onValueChange?.(nextValue);
+      },
+      value,
+    };
+
+    return (
+      <RadioGroupContext.Provider value={contextValue}>
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          role="radiogroup"
+          aria-disabled={disabled ? true : undefined}
+          aria-orientation={orientation}
+          className={radioGroupVariant(variantProps)}
+        >
+          {children}
+        </div>
+      </RadioGroupContext.Provider>
+    );
+  },
+);
+RadioGroup.displayName = "RadioGroup";
+
+interface RadioGroupItemProps
+  extends VariantProps<typeof radioGroupItemVariant>,
+    Omit<
+      React.ComponentPropsWithoutRef<"input">,
+      "checked" | "className" | "defaultChecked" | "name" | "size" | "type"
+    > {
+  children?: React.ReactNode;
+  value: string;
+}
+
+const RadioGroupItem = React.forwardRef<HTMLInputElement, RadioGroupItemProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveRadioGroupItemVariantProps(props);
+    const { children, disabled, onChange, value, ...otherPropsExtracted } =
+      otherPropsCompressed;
+
+    const group = useRadioGroupContext();
+    const isDisabled = group.disabled || disabled;
+    const isChecked = group.value === value;
+
+    return (
+      <label className={radioGroupItemVariant(variantProps)}>
+        <input
+          {...otherPropsExtracted}
+          ref={ref}
+          type="radio"
+          name={group.name}
+          value={value}
+          checked={isChecked}
+          disabled={isDisabled}
+          className="peer absolute inset-0 z-10 m-0 h-full w-full cursor-inherit opacity-0 disabled:cursor-not-allowed"
+          onChange={(event) => {
+            if (event.currentTarget.checked) {
+              group.setValue(value);
+            }
+
+            onChange?.(event);
+          }}
+        />
+        <span
+          aria-hidden
+          className="inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-neutral-400 bg-white text-white transition-colors duration-150 after:block after:size-2 after:scale-0 after:rounded-full after:bg-current after:transition-transform after:duration-150 after:content-[''] peer-checked:border-neutral-900 peer-checked:bg-neutral-900 peer-checked:after:scale-100 peer-disabled:border-neutral-300 peer-disabled:bg-neutral-100 dark:border-neutral-600 dark:bg-black dark:text-black dark:peer-checked:border-white dark:peer-checked:bg-white dark:peer-disabled:border-neutral-700 dark:peer-disabled:bg-neutral-900"
+        />
+        {children ? <span>{children}</span> : null}
+      </label>
+    );
+  },
+);
+RadioGroupItem.displayName = "RadioGroupItem";
+
+export { RadioGroup, RadioGroupItem };

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { Badge } from "../../components/Badge";
 import {
   Accordion,
   AccordionContent,
@@ -9,6 +8,7 @@ import {
 } from "../../components/Accordion";
 import { Alert, AlertDescription, AlertTitle } from "../../components/Alert";
 import { Avatar } from "../../components/Avatar";
+import { Badge } from "../../components/Badge";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -71,6 +71,7 @@ import {
   PopoverTrigger,
 } from "../../components/Popover";
 import { Progress } from "../../components/Progress";
+import { RadioGroup, RadioGroupItem } from "../../components/RadioGroup";
 import { Separator } from "../../components/Separator";
 import { Skeleton } from "../../components/Skeleton";
 import { Switch } from "../../components/Switch";
@@ -251,7 +252,7 @@ const BadgeShowcase = () => {
     </Section>
   );
 };
-  
+
 const BreadcrumbShowcase = () => {
   return (
     <Section
@@ -599,6 +600,36 @@ const ProgressShowcase = () => {
   );
 };
 
+const RadioGroupShowcase = () => {
+  const [value, setValue] = React.useState("starter");
+
+  return (
+    <Section
+      testId="radio-group"
+      title="Radio Group"
+      description="Controlled radio selection with native keyboard support."
+    >
+      <div className="flex flex-col gap-3">
+        <RadioGroup
+          aria-label="Plan"
+          value={value}
+          onValueChange={setValue}
+        >
+          <RadioGroupItem value="starter">Starter</RadioGroupItem>
+          <RadioGroupItem value="pro">Pro</RadioGroupItem>
+          <RadioGroupItem
+            value="enterprise"
+            disabled
+          >
+            Enterprise
+          </RadioGroupItem>
+        </RadioGroup>
+        <span data-testid="radio-group-state">{value}</span>
+      </div>
+    </Section>
+  );
+};
+
 const SeparatorShowcase = () => {
   return (
     <Section
@@ -740,7 +771,7 @@ const TableShowcase = () => {
     </Section>
   );
 };
-  
+
 const ToggleShowcase = () => {
   const [pressed, setPressed] = React.useState(false);
 
@@ -884,6 +915,7 @@ const showcases = [
   PaginationShowcase,
   PopoverShowcase,
   ProgressShowcase,
+  RadioGroupShowcase,
   SeparatorShowcase,
   SkeletonShowcase,
   SwitchShowcase,

--- a/packages/react/tests/radio-group.spec.ts
+++ b/packages/react/tests/radio-group.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("radio group updates selected value on click", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("radio-group-section");
+  const starter = section.getByRole("radio", { name: "Starter" });
+  const pro = section.getByRole("radio", { name: "Pro" });
+
+  await expect(starter).toBeChecked();
+  await pro.click();
+
+  await expect(pro).toBeChecked();
+  await expect(starter).not.toBeChecked();
+  await expect(section.getByTestId("radio-group-state")).toHaveText("pro");
+});
+
+test("radio group supports arrow-key navigation", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("radio-group-section");
+  const starter = section.getByRole("radio", { name: "Starter" });
+  const pro = section.getByRole("radio", { name: "Pro" });
+
+  await starter.focus();
+  await expect(starter).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+
+  await expect(pro).toBeChecked();
+  await expect(section.getByTestId("radio-group-state")).toHaveText("pro");
+});

--- a/registry.json
+++ b/registry.json
@@ -36,6 +36,7 @@
     "pagination": { "type": "file", "name": "Pagination.tsx" },
     "popover": { "type": "file", "name": "Popover.tsx" },
     "progress": { "type": "file", "name": "Progress.tsx" },
+    "radio-group": { "type": "file", "name": "RadioGroup.tsx" },
     "separator": { "type": "file", "name": "Separator.tsx" },
     "skeleton": { "type": "file", "name": "Skeleton.tsx" },
     "switch": { "type": "file", "name": "Switch.tsx" },


### PR DESCRIPTION
## Summary
- add a new `RadioGroup` / `RadioGroupItem` component pair with controlled or uncontrolled selection
- add a focused Playwright harness showcase and regression coverage for click selection and keyboard navigation
- register the component in `registry.json` and mark the roadmap item complete in `README.md`

## Testing
- `bun install`
- `bun --filter react test:e2e tests/radio-group.spec.ts`
- `bun run react:build`

## Preview
![Radio Group component preview](https://public.psw.kr/pswui-radio-group-pr-36.png)

@p-sw please take a look.
