### PR TITLE
fix: expose Textarea invalid state accessibly

### DIFF
--- a/packages/react/components/Textarea.tsx
+++ b/packages/react/components/Textarea.tsx
@@ -79,7 +79,13 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (props, ref) => {
     const [variantProps, otherPropsCompressed] =
       resolveTextareaVariantProps(props);
-    const { invalid, ...otherPropsExtracted } = otherPropsCompressed;
+    const {
+      invalid,
+      "aria-invalid": ariaInvalid,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const isInvalid = Boolean(invalid);
+    const resolvedAriaInvalid = isInvalid ? true : ariaInvalid;
 
     const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
 
@@ -91,6 +97,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     return (
       <textarea
+        aria-invalid={resolvedAriaInvalid}
         ref={(el) => {
           innerRef.current = el;
           if (typeof ref === "function") {

--- a/packages/react/tests/textarea.spec.ts
+++ b/packages/react/tests/textarea.spec.ts
@@ -2,20 +2,26 @@ import { expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
-test("textarea applies custom validity message", async ({ page }) => {
+test("textarea exposes semantic invalid state and custom validity message", async ({
+  page,
+}) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("textarea-section");
   const textarea = section.getByLabel("Feedback textarea");
 
+  await expect(textarea).toHaveAttribute("aria-invalid", "true");
+
   const validation = await textarea.evaluate((element) => {
     const target = element as HTMLTextAreaElement;
     return {
       customError: target.validity.customError,
+      valid: target.validity.valid,
       message: target.validationMessage,
     };
   });
 
   expect(validation.customError).toBe(true);
+  expect(validation.valid).toBe(false);
   expect(validation.message).toContain("Feedback is required");
 });


### PR DESCRIPTION
## Summary
- expose `aria-invalid` on `Textarea` when the component receives an `invalid` message
- keep caller-provided `aria-invalid` behavior unchanged when `invalid` is not set
- extend the existing Playwright textarea spec to cover both semantic invalid state and custom validity

## Validation
- bun install
- bun --filter react test:e2e tests/textarea.spec.ts
- bun run react:build

@p-sw