### PR TITLE
fix(progress): preserve custom className overrides

### DIFF
--- a/packages/react/components/Progress.tsx
+++ b/packages/react/components/Progress.tsx
@@ -17,10 +17,7 @@ const [progressVariant, resolveProgressVariantProps] = vcn({
 
 interface ProgressProps
   extends VariantProps<typeof progressVariant>,
-    Omit<
-      React.ComponentPropsWithoutRef<"progress">,
-      "className" | "max" | "value"
-    > {
+    Omit<React.ComponentPropsWithoutRef<"progress">, "max" | "value"> {
   max?: number;
   value?: number | null;
 }

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -587,6 +587,7 @@ const ProgressShowcase = () => {
       <div className="flex flex-col gap-4">
         <Progress
           aria-label="Upload progress"
+          className="bg-emerald-200"
           value={value}
           max={100}
         />

--- a/packages/react/tests/progress.spec.ts
+++ b/packages/react/tests/progress.spec.ts
@@ -17,6 +17,7 @@ test("progress exposes determinate and indeterminate state", async ({
 
   await expect(determinate).toHaveAttribute("aria-valuenow", "40");
   await expect(determinate).toHaveAttribute("aria-valuemax", "100");
+  await expect(determinate).toHaveClass(/bg-emerald-200/);
 
   await section.getByRole("button", { name: "Set progress to 75" }).click();
 


### PR DESCRIPTION
## Summary
- preserve caller-provided `className` on the existing `Progress` component so custom styling reaches the rendered `<progress>` element
- extend the progress Playwright harness/example to pass a custom class
- verify the existing progress spec asserts the forwarded class alongside current determinate/indeterminate behavior

## Validation
- `bun --filter react test:e2e tests/progress.spec.ts`
- `bun react:build`

@p-sw