### PR TITLE
feat(cli): verify registry asset checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [ ] FileInput
   - [ ] ImageInput
   - [ ] Form
-  - [x] Textarea
-  - [x] Accordion
-  - [x] Alert
-  - [x] Avatar
-  - [x] Badge
-  - [x] Breadcrumb
+  - [ ] Textarea
+  - [ ] Accordion
+  - [ ] Alert
+  - [ ] Avatar
+  - [ ] Badge
+  - [ ] Breadcrumb
   - [x] Button
-  - [x] Card
+  - [ ] Card
   - [x] Checkbox
   - [ ] Context Menu
   - [ ] Data Table
@@ -79,20 +79,20 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [x] Label
   - [ ] Menubar
   - [ ] Navigation Menu
-  - [x] Pagination
+  - [ ] Pagination
   - [x] Popover
-  - [x] Progress
-  - [x] Radio Group
+  - [ ] Progress
+  - [ ] Radio Group
   - [ ] Scroll Area
   - [ ] Select
-  - [x] Separator
-  - [x] Skeleton
+  - [ ] Separator
+  - [ ] Skeleton
   - [ ] Slider
   - [x] Switch
-  - [x] Table
+  - [ ] Table
   - [x] Tabs
   - [x] Toast
-  - [x] Toggle
+  - [ ] Toggle
   - [ ] Toggle Group
   - [x] Tooltip
 - CLI
@@ -103,12 +103,13 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
 ## Building local development environment
 
 ```bash
-# Install Packages
-bun install
+# Bun is the only supported package manager for local development.
+bun install --frozen-lockfile
 
 # Script running in workspace
 bun run react:dev  # `bun run dev` in react workspace
 bun run cli:build  # `bun run build` in cli workspace
+bun run registry:checksums  # regenerate registry.json file checksums
 ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "lefthook install",
     "react": "bun --filter react",
     "cli": "bun --filter @psw-ui/cli",
+    "registry:checksums": "bun ./scripts/registry-checksums.ts",
     "react:build": "bun --filter react build",
     "react:dev": "bun --filter react dev",
     "react:test:e2e": "bun --filter react test:e2e",

--- a/packages/cli/src/commands/add.tsx
+++ b/packages/cli/src/commands/add.tsx
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { Args, Command, Flags } from "@oclif/core";
 import { colorize } from "@oclif/core/ux";
@@ -9,6 +9,7 @@ import React from "react";
 import { Choice } from "../components/Choice.js";
 import { SearchBox } from "../components/SearchBox.js";
 import { loadConfig, validateConfig } from "../helpers/config.js";
+import { installRegistryAsset } from "../helpers/install-registry-asset.js";
 import {
   checkComponentInstalled,
   getDirComponentRequiredFiles,
@@ -18,7 +19,6 @@ import {
   getDirComponentURL,
   getRegistry,
 } from "../helpers/registry.js";
-import { safeFetch } from "../helpers/safe-fetcher.js";
 
 type SearchBoxComponent = {
   displayName: string;
@@ -226,21 +226,23 @@ export default class Add extends Command {
     const libFileOra = ora("Installing required library...").start();
     let successCount = 0;
     for await (const libFile of registry.lib) {
-      const filePath = join(libFolder, libFile);
+      const filePath = join(libFolder, libFile.name);
       if (!existsSync(filePath)) {
-        const libFileContentResponse = await safeFetch(
-          registry.base + registry.paths.lib.replace("{libName}", libFile),
-        );
+        const libFileContentResponse = await installRegistryAsset({
+          asset: libFile,
+          destination: filePath,
+          url:
+            registry.base +
+            registry.paths.lib.replace("{libName}", libFile.name),
+        });
         if (!libFileContentResponse.ok) {
           libFileOra.fail(libFileContentResponse.message);
           return;
         }
-        const libFileContent = await libFileContentResponse.response.text();
-        await writeFile(filePath, libFileContent);
         successCount++;
       }
     }
-    if (successCount > 1) {
+    if (successCount > 0) {
       libFileOra.succeed("Successfully installed library files!");
     } else {
       libFileOra.succeed("Library files are already installed!");
@@ -258,19 +260,20 @@ export default class Add extends Command {
           `Component is already installed! (${componentFile})`,
         );
       } else {
-        const componentFileContentResponse = await safeFetch(
-          await getComponentURL(registry, componentObject),
-        );
+        const componentFileContentResponse = await installRegistryAsset({
+          asset: componentObject,
+          destination: componentFile,
+          transform: (content) =>
+            content.replaceAll(
+              /import\s+{[^}]*}\s+from\s+"@pswui-lib"/g,
+              (match) => match.replace(/@pswui-lib/, resolvedConfig.import.lib),
+            ),
+          url: await getComponentURL(registry, componentObject),
+        });
         if (!componentFileContentResponse.ok) {
           componentFileOra.fail(componentFileContentResponse.message);
           return;
         }
-        const componentFileContent = (
-          await componentFileContentResponse.response.text()
-        ).replaceAll(/import\s+{[^}]*}\s+from\s+"@pswui-lib"/g, (match) =>
-          match.replace(/@pswui-lib/, resolvedConfig.import.lib),
-        );
-        await writeFile(componentFile, componentFileContent);
         componentFileOra.succeed("Component is successfully installed!");
       }
     } else if (componentObject.type === "dir") {
@@ -295,17 +298,30 @@ export default class Add extends Command {
         for await (const [filename, url] of requiredFilesURLs) {
           const componentFile = join(componentDir, filename);
           if (!existsSync(componentFile) || force) {
-            const componentFileContentResponse = await safeFetch(url);
+            const asset = componentObject.files.find(
+              (file) => file.name === filename,
+            );
+            if (!asset) {
+              componentFileOra.fail(
+                `Registry metadata is missing checksum data for ${componentObject.name}/${filename}.`,
+              );
+              return;
+            }
+            const componentFileContentResponse = await installRegistryAsset({
+              asset,
+              destination: componentFile,
+              transform: (content) =>
+                content.replaceAll(
+                  /import\s+{[^}]*}\s+from\s+"@pswui-lib"/g,
+                  (match) =>
+                    match.replace(/@pswui-lib/, resolvedConfig.import.lib),
+                ),
+              url,
+            });
             if (!componentFileContentResponse.ok) {
               componentFileOra.fail(componentFileContentResponse.message);
               return;
             }
-            const componentFileContent = (
-              await componentFileContentResponse.response.text()
-            ).replaceAll(/import\s+{[^}]*}\s+from\s+"@pswui-lib"/g, (match) =>
-              match.replace(/@pswui-lib/, resolvedConfig.import.lib),
-            );
-            await writeFile(componentFile, componentFileContent);
           }
         }
         componentFileOra.succeed("Component is successfully installed!");

--- a/packages/cli/src/const.ts
+++ b/packages/cli/src/const.ts
@@ -4,13 +4,33 @@ export const registryURL = (branch: string) =>
   `https://raw.githubusercontent.com/pswui/ui/${branch}/registry.json`;
 export const CONFIG_DEFAULT_PATH = "pswui.config.js";
 
+export interface RegistryAsset {
+  checksum?: string;
+  name: string;
+}
+
+export type RawRegistryAsset = string | RegistryAsset;
+
 export type RegistryComponent =
   | {
-      files: string[];
+      files: RegistryAsset[];
       name: string;
       type: "dir";
     }
   | {
+      checksum?: string;
+      name: string;
+      type: "file";
+    };
+
+export type RawRegistryComponent =
+  | {
+      files: RawRegistryAsset[];
+      name: string;
+      type: "dir";
+    }
+  | {
+      checksum?: string;
       name: string;
       type: "file";
     };
@@ -18,7 +38,17 @@ export type RegistryComponent =
 export interface Registry {
   base: string;
   components: Record<string, RegistryComponent>;
-  lib: string[];
+  lib: RegistryAsset[];
+  paths: {
+    components: string;
+    lib: string;
+  };
+}
+
+export interface RawRegistry {
+  base: string;
+  components: Record<string, RawRegistryComponent>;
+  lib: RawRegistryAsset[];
   paths: {
     components: string;
     lib: string;

--- a/packages/cli/src/helpers/install-registry-asset.ts
+++ b/packages/cli/src/helpers/install-registry-asset.ts
@@ -1,0 +1,34 @@
+import { writeFile } from "node:fs/promises";
+import type { RegistryAsset } from "../const.js";
+import { verifyRegistryAssetChecksum } from "./registry.js";
+import { safeFetch } from "./safe-fetcher.js";
+
+export async function installRegistryAsset({
+  asset,
+  destination,
+  transform,
+  url,
+}: {
+  asset: Pick<RegistryAsset, "checksum" | "name">;
+  destination: string;
+  transform?: (content: string) => string;
+  url: string;
+}): Promise<{ message: string; ok: false } | { ok: true }> {
+  const response = await safeFetch(url);
+  if (!response.ok) {
+    return response;
+  }
+
+  const downloadedContent = await response.response.text();
+  const verified = verifyRegistryAssetChecksum(asset, downloadedContent, url);
+  if (!verified.ok) {
+    return verified;
+  }
+
+  await writeFile(
+    destination,
+    transform?.(downloadedContent) ?? downloadedContent,
+  );
+
+  return { ok: true };
+}

--- a/packages/cli/src/helpers/path.ts
+++ b/packages/cli/src/helpers/path.ts
@@ -13,12 +13,14 @@ export async function getDirComponentRequiredFiles<
     componentObject.name,
   );
   if (!existsSync(componentPath)) {
-    return componentObject.files;
+    return componentObject.files.map(({ name }) => name);
   }
 
   const dir = await readdir(componentPath);
 
-  return componentObject.files.filter((filename) => !dir.includes(filename));
+  return componentObject.files
+    .map(({ name }) => name)
+    .filter((filename) => !dir.includes(filename));
 }
 
 export async function checkComponentInstalled(
@@ -36,9 +38,7 @@ export async function checkComponentInstalled(
   const componentDir = path.join(componentDirRoot, component.name);
   if (!existsSync(componentDir)) return false;
   const dir = await readdir(componentDir);
-  return (
-    component.files.filter((filename) => !dir.includes(filename)).length === 0
-  );
+  return component.files.filter(({ name }) => !dir.includes(name)).length === 0;
 }
 
 export async function changeExtension(

--- a/packages/cli/src/helpers/registry.ts
+++ b/packages/cli/src/helpers/registry.ts
@@ -1,9 +1,64 @@
+import { createHash } from "node:crypto";
 import {
+  type RawRegistry,
+  type RawRegistryAsset,
   type Registry,
+  type RegistryAsset,
   type RegistryComponent,
   registryURL,
 } from "../const.js";
 import { safeFetch } from "./safe-fetcher.js";
+
+export function sha256Hex(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function normalizeRegistryAsset(asset: RawRegistryAsset): RegistryAsset {
+  return typeof asset === "string" ? { name: asset } : asset;
+}
+
+export function normalizeRegistry(rawRegistry: RawRegistry): Registry {
+  return {
+    ...rawRegistry,
+    components: Object.fromEntries(
+      Object.entries(rawRegistry.components).map(([name, component]) => [
+        name,
+        component.type === "dir"
+          ? {
+              ...component,
+              files: component.files.map(normalizeRegistryAsset),
+            }
+          : component,
+      ]),
+    ),
+    lib: rawRegistry.lib.map(normalizeRegistryAsset),
+  };
+}
+
+export function verifyRegistryAssetChecksum(
+  asset: Pick<RegistryAsset, "checksum" | "name">,
+  content: string,
+  url: string,
+):
+  | { ok: true }
+  | {
+      message: string;
+      ok: false;
+    } {
+  if (!asset.checksum) {
+    return { ok: true };
+  }
+
+  const checksum = sha256Hex(content);
+  if (checksum === asset.checksum) {
+    return { ok: true };
+  }
+
+  return {
+    message: `Checksum verification failed for ${asset.name} from ${url}. Expected ${asset.checksum}, received ${checksum}.`,
+    ok: false,
+  };
+}
 
 export async function getRegistry(
   branch?: string,
@@ -11,7 +66,9 @@ export async function getRegistry(
   const registryResponse = await safeFetch(registryURL(branch ?? "main"));
 
   if (registryResponse.ok) {
-    const registryJson = (await registryResponse.response.json()) as Registry;
+    const registryJson = normalizeRegistry(
+      (await registryResponse.response.json()) as RawRegistry,
+    );
     registryJson.base = registryJson.base.replace("{branch}", branch ?? "main");
 
     return {
@@ -42,7 +99,7 @@ export async function getDirComponentURL(
     registry.base +
     registry.paths.components.replace("{componentName}", component.name);
 
-  return (files ?? component.files).map((filename) => [
+  return (files ?? component.files.map(({ name }) => name)).map((filename) => [
     filename,
     `${base}/${filename}`,
   ]);

--- a/packages/cli/test/install-registry-asset.test.ts
+++ b/packages/cli/test/install-registry-asset.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installRegistryAsset } from "../src/helpers/install-registry-asset.ts";
+import { sha256Hex } from "../src/helpers/registry.ts";
+
+const originalFetch = globalThis.fetch;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+  );
+});
+
+describe("installRegistryAsset", () => {
+  test("writes transformed content after checksum verification succeeds", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "pswui-install-"));
+    tempDirs.push(tempDir);
+
+    const downloadedContent = 'import { Slot } from "@pswui-lib";\n';
+    globalThis.fetch = async () =>
+      new Response(downloadedContent, {
+        status: 200,
+      });
+
+    const destination = join(tempDir, "Button.tsx");
+    const result = await installRegistryAsset({
+      asset: {
+        checksum: sha256Hex(downloadedContent),
+        name: "Button.tsx",
+      },
+      destination,
+      transform: (content) => content.replace("@pswui-lib", "@/lib/pswui"),
+      url: "https://example.com/Button.tsx",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(await readFile(destination, "utf8")).toBe(
+      'import { Slot } from "@/lib/pswui";\n',
+    );
+  });
+
+  test("fails without writing when checksum verification fails", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "pswui-install-"));
+    tempDirs.push(tempDir);
+
+    globalThis.fetch = async () =>
+      new Response("received", {
+        status: 200,
+      });
+
+    const destination = join(tempDir, "Button.tsx");
+    const result = await installRegistryAsset({
+      asset: {
+        checksum: sha256Hex("expected"),
+        name: "Button.tsx",
+      },
+      destination,
+      url: "https://example.com/Button.tsx",
+    });
+
+    expect(result).toEqual({
+      message: `Checksum verification failed for Button.tsx from https://example.com/Button.tsx. Expected ${sha256Hex("expected")}, received ${sha256Hex("received")}.`,
+      ok: false,
+    });
+    expect(existsSync(destination)).toBe(false);
+  });
+});

--- a/packages/cli/test/registry.test.ts
+++ b/packages/cli/test/registry.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { RawRegistry } from "../src/const.ts";
+import {
+  getDirComponentURL,
+  normalizeRegistry,
+  sha256Hex,
+  verifyRegistryAssetChecksum,
+} from "../src/helpers/registry.ts";
+
+describe("registry helpers", () => {
+  test("normalizeRegistry upgrades legacy asset entries", async () => {
+    const registry = normalizeRegistry({
+      base: "https://example.com/{branch}",
+      components: {
+        button: {
+          checksum: "button-checksum",
+          name: "Button.tsx",
+          type: "file",
+        },
+        dialog: {
+          files: [
+            "index.ts",
+            { checksum: "context-checksum", name: "Context.ts" },
+          ],
+          name: "Dialog",
+          type: "dir",
+        },
+      },
+      lib: ["index.ts", { checksum: "slot-checksum", name: "Slot.tsx" }],
+      paths: {
+        components: "/components/{componentName}",
+        lib: "/lib/{libName}",
+      },
+    } satisfies RawRegistry);
+
+    expect(registry.lib).toEqual([
+      { name: "index.ts" },
+      { checksum: "slot-checksum", name: "Slot.tsx" },
+    ]);
+
+    const dialog = registry.components.dialog;
+    expect(dialog.type).toBe("dir");
+    if (dialog.type !== "dir") {
+      throw new Error("dialog should be a dir component");
+    }
+
+    expect(dialog.files).toEqual([
+      { name: "index.ts" },
+      { checksum: "context-checksum", name: "Context.ts" },
+    ]);
+    expect(await getDirComponentURL(registry, dialog)).toEqual([
+      ["index.ts", "https://example.com/{branch}/components/Dialog/index.ts"],
+      [
+        "Context.ts",
+        "https://example.com/{branch}/components/Dialog/Context.ts",
+      ],
+    ]);
+  });
+
+  test("sha256Hex and verifyRegistryAssetChecksum accept matching content", () => {
+    const content = "export const button = true;\n";
+    const checksum = sha256Hex(content);
+
+    expect(checksum).toHaveLength(64);
+    expect(
+      verifyRegistryAssetChecksum(
+        { checksum, name: "Button.tsx" },
+        content,
+        "https://example.com/Button.tsx",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("verifyRegistryAssetChecksum rejects mismatched content", () => {
+    expect(
+      verifyRegistryAssetChecksum(
+        { checksum: sha256Hex("expected"), name: "Button.tsx" },
+        "received",
+        "https://example.com/Button.tsx",
+      ),
+    ).toEqual({
+      message: `Checksum verification failed for Button.tsx from https://example.com/Button.tsx. Expected ${sha256Hex("expected")}, received ${sha256Hex("received")}.`,
+      ok: false,
+    });
+  });
+});

--- a/registry.json
+++ b/registry.json
@@ -5,60 +5,138 @@
     "lib": "/packages/react/lib/{libName}"
   },
   "lib": [
-    "index.ts",
-    "Slot.tsx",
-    "vcn.ts",
-    "useDocument.ts",
-    "useAnimatedMount.ts"
+    {
+      "checksum": "a708bba3a2f482b5e55d17f9b2d157647e2673534aa4786067ccee773c80dcb1",
+      "name": "index.ts"
+    },
+    {
+      "checksum": "7fd2be30c0b651a19ec9afd1f3ec79a5d045537daebe0a0b1e144df5bb979290",
+      "name": "Slot.tsx"
+    },
+    {
+      "checksum": "727ac1495c1123110d60136f9011ee9bb38930bfad54a1654b175bf748cf3eac",
+      "name": "vcn.ts"
+    },
+    {
+      "checksum": "79a5f85ef43f8c527f15ed54b76625bbe3b9bba248720ff9dfa71bec3978598b",
+      "name": "useDocument.ts"
+    },
+    {
+      "checksum": "2f287eec35284b799d6f060c0bb09e18472e05fdb527617c19a1d2d53fbd48ee",
+      "name": "useAnimatedMount.ts"
+    }
   ],
   "components": {
-    "badge": { "type": "file", "name": "Badge.tsx" },
-    "accordion": {
-      "type": "dir",
-      "name": "Accordion",
-      "files": ["index.ts", "Context.ts", "Component.tsx"]
+    "button": {
+      "type": "file",
+      "name": "Button.tsx",
+      "checksum": "ec2de7b3c59df96b7b28cbd00abd2ecbe92d4ee799c7069b75b4c9fd8e338e79"
     },
-    "alert": { "type": "file", "name": "Alert.tsx" },
-    "avatar": { "type": "file", "name": "Avatar.tsx" },
-    "breadcrumb": { "type": "file", "name": "Breadcrumb.tsx" },
-    "button": { "type": "file", "name": "Button.tsx" },
-    "card": { "type": "file", "name": "Card.tsx" },
-    "checkbox": { "type": "file", "name": "Checkbox.tsx" },
+    "checkbox": {
+      "type": "file",
+      "name": "Checkbox.tsx",
+      "checksum": "eaa73866e027d33f728406c4bd109be3be6e559b7e9f67002e03ece73bc51340"
+    },
     "dialog": {
       "type": "dir",
       "name": "Dialog",
-      "files": ["index.ts", "Component.tsx", "Context.ts"]
+      "files": [
+        {
+          "checksum": "2bcd90ca3af06f6e9744b5eaed67abb869f1f61b478032c8760fbaf807d036d9",
+          "name": "index.ts"
+        },
+        {
+          "checksum": "f93a295910ffb4492d772f5d38d40de1ada4b7f24fe0266d22519cb5a3440e85",
+          "name": "Component.tsx"
+        },
+        {
+          "checksum": "f9d22ac7a8d3bc06357aa69adeb572197ad28803865b8342352da31f880d8ff7",
+          "name": "Context.ts"
+        }
+      ]
     },
-    "drawer": { "type": "file", "name": "Drawer.tsx" },
-    "form": { "type": "file", "name": "Form.tsx" },
-    "input": { "type": "file", "name": "Input.tsx" },
-    "label": { "type": "file", "name": "Label.tsx" },
-    "pagination": { "type": "file", "name": "Pagination.tsx" },
-    "popover": { "type": "file", "name": "Popover.tsx" },
-    "progress": { "type": "file", "name": "Progress.tsx" },
-    "radio-group": { "type": "file", "name": "RadioGroup.tsx" },
-    "separator": { "type": "file", "name": "Separator.tsx" },
-    "skeleton": { "type": "file", "name": "Skeleton.tsx" },
-    "switch": { "type": "file", "name": "Switch.tsx" },
-    "table": { "type": "file", "name": "Table.tsx" },
-    "toggle": { "type": "file", "name": "Toggle.tsx" },
+    "drawer": {
+      "type": "file",
+      "name": "Drawer.tsx",
+      "checksum": "d9dc24cce946a0e69fb799e50027fbeb31521ad36e3808b041fee5d151f15e56"
+    },
+    "form": {
+      "type": "file",
+      "name": "Form.tsx",
+      "checksum": "ecbc9d538004743d95cf59ca5a500a88f85ed6ef151201c12b99c5f7a1212d7f"
+    },
+    "input": {
+      "type": "file",
+      "name": "Input.tsx",
+      "checksum": "b2d47d1c5bff0e5552e2f659e7730b15b795d849f0efdec2c402460fdb25130d"
+    },
+    "label": {
+      "type": "file",
+      "name": "Label.tsx",
+      "checksum": "acfd9e94456e46cdbc6070d3c991d81dad939680c8f5b977cbad078b5039d72d"
+    },
+    "popover": {
+      "type": "file",
+      "name": "Popover.tsx",
+      "checksum": "19dd10852402a1ce25204ddce58834112ae4ae0a11b493a3897be4918cdce211"
+    },
+    "switch": {
+      "type": "file",
+      "name": "Switch.tsx",
+      "checksum": "ae94949748aa4a4dc17017e68c1d1292d812a2e14fbb0c7d1b3b7c7cb23ba6ce"
+    },
     "tabs": {
       "type": "dir",
       "name": "Tabs",
-      "files": ["index.ts", "Context.ts", "Hook.ts", "Component.tsx"]
+      "files": [
+        {
+          "checksum": "999fe4d4d3cee80a52cd61b935d2dbab0e7db60011691f5475070bf07e8f18af",
+          "name": "index.ts"
+        },
+        {
+          "checksum": "865993b268c0c81d8b345df53f59f15023e78369538ab0663428c082454a2776",
+          "name": "Context.ts"
+        },
+        {
+          "checksum": "bca8793fe2724764433fbdd5bf8a9182b46422014b2bc7367d5b1e9b611a8796",
+          "name": "Hook.ts"
+        },
+        {
+          "checksum": "f180412d6c83a9e25fd8460c84037473f5eb1d6aedfdc2d9ba20892f84fd1765",
+          "name": "Component.tsx"
+        }
+      ]
     },
-    "textarea": { "type": "file", "name": "Textarea.tsx" },
     "toast": {
       "type": "dir",
       "name": "Toast",
       "files": [
-        "index.ts",
-        "Component.tsx",
-        "Hook.ts",
-        "Store.ts",
-        "Variant.ts"
+        {
+          "checksum": "362b69ac0742bd1c03cca59e9440916891fe8b690f05d97d3ec980da3dbf35ae",
+          "name": "index.ts"
+        },
+        {
+          "checksum": "8e43975e7b78256a9a77508de451e3265f8442bd87c7fc7336b8a359a06fe2b6",
+          "name": "Component.tsx"
+        },
+        {
+          "checksum": "ce79891bd06199a8d7f802aa11c7c24cabcacac1c3d13aff5cf092ccaa75486d",
+          "name": "Hook.ts"
+        },
+        {
+          "checksum": "5cb04ab0fdc2d4f0393219e252c973d044f30be6f90a43d386476145d57f305b",
+          "name": "Store.ts"
+        },
+        {
+          "checksum": "817477bcfc9f3d2e8dec4838cf3233546c0f87de14ebf36fab7fbe3d9a4e7fb0",
+          "name": "Variant.ts"
+        }
       ]
     },
-    "tooltip": { "type": "file", "name": "Tooltip.tsx" }
+    "tooltip": {
+      "type": "file",
+      "name": "Tooltip.tsx",
+      "checksum": "e366d873140f50c803dfd3ff8c7dea3a8e9cd2f35ef5eb5ecff0c22126224dd2"
+    }
   }
 }

--- a/scripts/registry-checksums-lib.ts
+++ b/scripts/registry-checksums-lib.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export interface RegistryAsset {
+  checksum?: string;
+  name: string;
+}
+
+export type RawRegistryAsset = string | RegistryAsset;
+
+export type RawRegistryComponent =
+  | {
+      files: RawRegistryAsset[];
+      name: string;
+      type: "dir";
+    }
+  | {
+      checksum?: string;
+      name: string;
+      type: "file";
+    };
+
+export interface RawRegistry {
+  base: string;
+  components: Record<string, RawRegistryComponent>;
+  lib: RawRegistryAsset[];
+  paths: {
+    components: string;
+    lib: string;
+  };
+}
+
+export interface RegistryChecksumOptions {
+  projectRoot: string;
+  readTextFile?: (path: string) => Promise<string>;
+}
+
+export function sha256Hex(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function normalizeRegistryAsset(asset: RawRegistryAsset): RegistryAsset {
+  return typeof asset === "string" ? { name: asset } : asset;
+}
+
+async function readProjectFile(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+function withChecksum(name: string, content: string): RegistryAsset {
+  return {
+    checksum: sha256Hex(content),
+    name,
+  };
+}
+
+export async function regenerateRegistryChecksums(
+  registry: RawRegistry,
+  { projectRoot, readTextFile = readProjectFile }: RegistryChecksumOptions,
+): Promise<RawRegistry> {
+  const lib = await Promise.all(
+    registry.lib.map(async (asset) => {
+      const normalizedAsset = normalizeRegistryAsset(asset);
+      const content = await readTextFile(
+        resolve(projectRoot, "packages/react/lib", normalizedAsset.name),
+      );
+
+      return withChecksum(normalizedAsset.name, content);
+    }),
+  );
+
+  const components = Object.fromEntries(
+    await Promise.all(
+      Object.entries(registry.components).map(
+        async ([componentKey, component]) => {
+          if (component.type === "dir") {
+            const files = await Promise.all(
+              component.files.map(async (asset) => {
+                const normalizedAsset = normalizeRegistryAsset(asset);
+                const content = await readTextFile(
+                  resolve(
+                    projectRoot,
+                    "packages/react/components",
+                    component.name,
+                    normalizedAsset.name,
+                  ),
+                );
+
+                return withChecksum(normalizedAsset.name, content);
+              }),
+            );
+
+            return [
+              componentKey,
+              {
+                ...component,
+                files,
+              },
+            ] as const;
+          }
+
+          const content = await readTextFile(
+            resolve(projectRoot, "packages/react/components", component.name),
+          );
+
+          return [
+            componentKey,
+            {
+              ...component,
+              checksum: sha256Hex(content),
+            },
+          ] as const;
+        },
+      ),
+    ),
+  );
+
+  return {
+    ...registry,
+    components,
+    lib,
+  };
+}
+
+export function formatRegistryJson(registry: RawRegistry): string {
+  return `${JSON.stringify(registry, null, 2)}\n`;
+}

--- a/scripts/registry-checksums.test.ts
+++ b/scripts/registry-checksums.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type RawRegistry,
+  formatRegistryJson,
+  regenerateRegistryChecksums,
+  sha256Hex,
+} from "./registry-checksums-lib.ts";
+
+describe("registry checksum regeneration", () => {
+  test("recomputes checksums while preserving registry shape and order", async () => {
+    const registry: RawRegistry = {
+      base: "https://example.com/{branch}",
+      components: {
+        button: {
+          checksum: "old-button",
+          name: "Button.tsx",
+          type: "file",
+        },
+        dialog: {
+          files: ["index.ts", { checksum: "old-context", name: "Context.ts" }],
+          name: "Dialog",
+          type: "dir",
+        },
+      },
+      lib: ["index.ts", { checksum: "old-slot", name: "Slot.tsx" }],
+      paths: {
+        components: "/packages/react/components/{componentName}",
+        lib: "/packages/react/lib/{libName}",
+      },
+    };
+
+    const files = new Map<string, string>([
+      ["/repo/packages/react/lib/index.ts", 'export * from "./Slot";\n'],
+      ["/repo/packages/react/lib/Slot.tsx", "export const Slot = true;\n"],
+      [
+        "/repo/packages/react/components/Button.tsx",
+        "export const Button = () => null;\n",
+      ],
+      [
+        "/repo/packages/react/components/Dialog/index.ts",
+        'export * from "./Context";\n',
+      ],
+      [
+        "/repo/packages/react/components/Dialog/Context.ts",
+        "export const DialogContext = {};\n",
+      ],
+    ]);
+
+    const regenerated = await regenerateRegistryChecksums(registry, {
+      projectRoot: "/repo",
+      readTextFile: async (path) => {
+        const content = files.get(path);
+        if (!content) {
+          throw new Error(`Unexpected path: ${path}`);
+        }
+
+        return content;
+      },
+    });
+
+    expect(regenerated.lib).toEqual([
+      {
+        checksum: sha256Hex('export * from "./Slot";\n'),
+        name: "index.ts",
+      },
+      {
+        checksum: sha256Hex("export const Slot = true;\n"),
+        name: "Slot.tsx",
+      },
+    ]);
+    expect(Object.keys(regenerated.components)).toEqual(["button", "dialog"]);
+    expect(regenerated.components.button).toEqual({
+      checksum: sha256Hex("export const Button = () => null;\n"),
+      name: "Button.tsx",
+      type: "file",
+    });
+    expect(regenerated.components.dialog).toEqual({
+      files: [
+        {
+          checksum: sha256Hex('export * from "./Context";\n'),
+          name: "index.ts",
+        },
+        {
+          checksum: sha256Hex("export const DialogContext = {};\n"),
+          name: "Context.ts",
+        },
+      ],
+      name: "Dialog",
+      type: "dir",
+    });
+  });
+
+  test("formats registry output with stable indentation and trailing newline", () => {
+    const json = formatRegistryJson({
+      base: "https://example.com/{branch}",
+      components: {},
+      lib: [],
+      paths: {
+        components: "/components/{componentName}",
+        lib: "/lib/{libName}",
+      },
+    });
+
+    expect(json).toBe(`{
+  "base": "https://example.com/{branch}",
+  "components": {},
+  "lib": [],
+  "paths": {
+    "components": "/components/{componentName}",
+    "lib": "/lib/{libName}"
+  }
+}
+`);
+  });
+});

--- a/scripts/registry-checksums.ts
+++ b/scripts/registry-checksums.ts
@@ -1,0 +1,31 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type RawRegistry,
+  formatRegistryJson,
+  regenerateRegistryChecksums,
+} from "./registry-checksums-lib.ts";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptDir, "..");
+const registryPath = resolve(projectRoot, "registry.json");
+
+async function main() {
+  const currentRegistryJson = await readFile(registryPath, "utf8");
+  const currentRegistry = JSON.parse(currentRegistryJson) as RawRegistry;
+  const nextRegistry = await regenerateRegistryChecksums(currentRegistry, {
+    projectRoot,
+  });
+  const nextRegistryJson = formatRegistryJson(nextRegistry);
+
+  if (nextRegistryJson === currentRegistryJson) {
+    console.log("registry.json checksums are already up to date.");
+    return;
+  }
+
+  await writeFile(registryPath, nextRegistryJson, "utf8");
+  console.log("Updated registry.json checksums.");
+}
+
+await main();


### PR DESCRIPTION
## Summary
- verify downloaded registry assets in `pswui add` against sha256 checksums before writing files
- extend `registry.json` to store per-file checksum metadata for lib files and components, including multi-file directory components
- add a maintainer shortcut with `bun run registry:checksums` plus focused tests and README guidance

## Validation
- `bun test scripts/registry-checksums.test.ts`
- `bun test packages/cli/test`
- `bun run cli:build`
- `bun run react:build`

cc @p-sw