### PR TITLE
chore(registry): sync component inventory and milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [x] Input
   - [ ] FileInput
   - [ ] ImageInput
-  - [ ] Form
-  - [ ] Textarea
-  - [ ] Accordion
-  - [ ] Alert
-  - [ ] Avatar
-  - [ ] Badge
-  - [ ] Breadcrumb
+  - [x] Form
+  - [x] Textarea
+  - [x] Accordion
+  - [x] Alert
+  - [x] Avatar
+  - [x] Badge
+  - [x] Breadcrumb
   - [x] Button
-  - [ ] Card
+  - [x] Card
   - [x] Checkbox
   - [ ] Context Menu
   - [ ] Data Table
@@ -79,17 +79,17 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
   - [x] Label
   - [ ] Menubar
   - [ ] Navigation Menu
-  - [ ] Pagination
+  - [x] Pagination
   - [x] Popover
-  - [ ] Progress
-  - [ ] Radio Group
-  - [] Scroll Area
+  - [x] Progress
+  - [x] Radio Group
+  - [x] Scroll Area
   - [x] Select
   - [x] Separator
   - [x] Skeleton
   - [x] Slider
   - [x] Switch
-  - [ ] Table
+  - [x] Table
   - [x] Tabs
   - [x] Toast
   - [x] Toggle

--- a/registry.json
+++ b/registry.json
@@ -27,10 +27,53 @@
     }
   ],
   "components": {
+    "accordion": {
+      "type": "dir",
+      "name": "Accordion",
+      "files": [
+        {
+          "checksum": "c9e12797a8b2c6623572499b30678f70ad6f2819c56665cd843100c9fac1ab34",
+          "name": "index.ts"
+        },
+        {
+          "checksum": "919f6e5f7ef3cc7460d26085cc16df096d84528c60e0520761fb664264ca6ce6",
+          "name": "Component.tsx"
+        },
+        {
+          "checksum": "b0ae9014990a5af15998dc25344665e9feb89c80befee71bf93b3693bd78d661",
+          "name": "Context.ts"
+        }
+      ]
+    },
+    "alert": {
+      "type": "file",
+      "name": "Alert.tsx",
+      "checksum": "990217920bbadd3c7efe73b67d90da523f10aed92c7c18c5f7d7456de6bc1a91"
+    },
+    "avatar": {
+      "type": "file",
+      "name": "Avatar.tsx",
+      "checksum": "d870900d76cbe766baf1068f640339b25ec3ab323df7b8c296d2dbb618dc38ce"
+    },
+    "badge": {
+      "type": "file",
+      "name": "Badge.tsx",
+      "checksum": "e1406a1f67178b938afd6c7cce16c1f193a2ee710674a590a23ea947ec4432b7"
+    },
+    "breadcrumb": {
+      "type": "file",
+      "name": "Breadcrumb.tsx",
+      "checksum": "2920e724c783fb37ec413bf897998f18511e80e8ca56676639aca8c4a46ea91a"
+    },
     "button": {
       "type": "file",
       "name": "Button.tsx",
       "checksum": "f554d9dd76f649a2b1f33a8e047c485d1b9136e4b11149040a0ecc156cb5c464"
+    },
+    "card": {
+      "type": "file",
+      "name": "Card.tsx",
+      "checksum": "eceab4a86dd98dd42681587cc217972e3d1f8eb5e45f1203b969f430d1f6a9ac"
     },
     "checkbox": {
       "type": "file",
@@ -58,7 +101,7 @@
     "drawer": {
       "type": "file",
       "name": "Drawer.tsx",
-      "checksum": "637d8f5ab5ea55d48eff0d9a498c2b9dac23c68812dc4cf7088ce1ed89f97734"
+      "checksum": "610c6287f8166c7684c184867808e8c78d795765be3ea460bda8eb7f03408c73"
     },
     "form": {
       "type": "file",
@@ -75,20 +118,60 @@
       "name": "Label.tsx",
       "checksum": "d832854bcbc0070455c1f643910872d4f0f0e216919294b34314f819ebbbe8b6"
     },
+    "pagination": {
+      "type": "file",
+      "name": "Pagination.tsx",
+      "checksum": "535735de1d5fcea503db3d5edfa526b22b2fad0635913d3b65b462aad4fb38fa"
+    },
     "popover": {
       "type": "file",
       "name": "Popover.tsx",
       "checksum": "4963287e861644de7e0fa2722cf567e60a3927c7c1ea28f38a3e4a6de8e763d1"
+    },
+    "progress": {
+      "type": "file",
+      "name": "Progress.tsx",
+      "checksum": "c67e6a3632d21abfeba6282b2b0fde49335cf84c19d6268cc60d3890f8b35653"
+    },
+    "radio-group": {
+      "type": "file",
+      "name": "RadioGroup.tsx",
+      "checksum": "15e1b94582b505be576e0be9b77b258444f2ac10808cd89f6446f40b0a5c005f"
     },
     "scroll-area": {
       "type": "file",
       "name": "ScrollArea.tsx",
       "checksum": "2869883734755c875ad09e504d28f53b39aee9063bdac84e613e68e6fc121467"
     },
+    "select": {
+      "type": "file",
+      "name": "Select.tsx",
+      "checksum": "9f962b65cd18fb91e32ef21038f0d6b3b8f8fb5c6627a677192bc18c9e18daab"
+    },
+    "separator": {
+      "type": "file",
+      "name": "Separator.tsx",
+      "checksum": "1a4d6fe8056bcc43b605c36a1334fec027d95f1dd26b39bc69d8c71a158d591b"
+    },
+    "skeleton": {
+      "type": "file",
+      "name": "Skeleton.tsx",
+      "checksum": "cadec688b2f5e18bfa6a9a81b3bf715ff712a10333167a0c60458cb27c22f003"
+    },
+    "slider": {
+      "type": "file",
+      "name": "Slider.tsx",
+      "checksum": "c4a13d90f8b86d9cf00299b9351d4c250e01cf6d53b2b6f0c07a5c674cd38436"
+    },
     "switch": {
       "type": "file",
       "name": "Switch.tsx",
       "checksum": "1a4ef190e084f6dee1f5ec9adbf62ae44022fce141856eb5a2382ef956210b32"
+    },
+    "table": {
+      "type": "file",
+      "name": "Table.tsx",
+      "checksum": "229e766dfc70de2683ffd86dad8f872c743ffd35d1c854d28d7992bbe5da1ec3"
     },
     "tabs": {
       "type": "dir",
@@ -111,6 +194,11 @@
           "name": "Component.tsx"
         }
       ]
+    },
+    "textarea": {
+      "type": "file",
+      "name": "Textarea.tsx",
+      "checksum": "eec2ae9ce1b4215a80c2d2074b6dbad3c383a5661ed57eed109ca51dc1c78ada"
     },
     "toast": {
       "type": "dir",
@@ -137,6 +225,16 @@
           "name": "Variant.ts"
         }
       ]
+    },
+    "toggle": {
+      "type": "file",
+      "name": "Toggle.tsx",
+      "checksum": "9b02cbd43ede02317022c40c83083e185fa7c90e35d5d107f38c14ac24bedfea"
+    },
+    "toggle-group": {
+      "type": "file",
+      "name": "ToggleGroup.tsx",
+      "checksum": "60f649520896376f47adb24f5999df8e5996281b97267655184bab83573f6c9f"
     },
     "tooltip": {
       "type": "file",


### PR DESCRIPTION
## Summary
- add currently shipped React components to `registry.json` using the checksum-backed schema
- regenerate registry checksums so the CLI inventory matches the latest component sources
- update the README component milestone checklist to mark implemented components correctly and fix the malformed Scroll Area checkbox

## Validation
- `bun run registry:checksums`
- `bun run cli:build`

cc @p-sw