### PR TITLE
fix: preserve Alert custom className with variants

### DIFF
--- a/packages/react/components/Alert.tsx
+++ b/packages/react/components/Alert.tsx
@@ -25,6 +25,7 @@ interface AlertProps
     AsChild {}
 
 const Alert = React.forwardRef<HTMLElement, AlertProps>((props, ref) => {
+  const { className } = props;
   const [variantProps, otherPropsCompressed] = resolveAlertVariantProps(props);
   const { asChild, role, ...otherPropsExtracted } = otherPropsCompressed;
 
@@ -34,8 +35,8 @@ const Alert = React.forwardRef<HTMLElement, AlertProps>((props, ref) => {
     <Comp
       ref={ref}
       role={role ?? "alert"}
-      className={alertVariant(variantProps)}
       {...otherPropsExtracted}
+      className={alertVariant({ ...variantProps, className })}
     />
   );
 });

--- a/packages/react/tests/alert.spec.ts
+++ b/packages/react/tests/alert.spec.ts
@@ -10,6 +10,7 @@ test("alert renders semantic structure and supports status variants", async ({
   const section = page.getByTestId("alert-section");
   const defaultAlert = section.getByTestId("alert-default");
   const successAlert = section.getByTestId("alert-success");
+  const customAlert = section.getByTestId("alert-custom");
 
   await expect(defaultAlert).toHaveJSProperty("tagName", "SECTION");
   await expect(defaultAlert).toHaveAttribute("role", "alert");
@@ -28,5 +29,16 @@ test("alert renders semantic structure and supports status variants", async ({
   ).toBeVisible();
   await expect(successAlert).toContainText(
     "Your profile settings were stored successfully.",
+  );
+
+  await expect(customAlert).toHaveAttribute("role", "alert");
+  await expect(customAlert).toHaveClass(/alert-custom-frame/);
+  await expect(customAlert).toHaveClass(/border-red-400/);
+  await expect(customAlert).toHaveClass(/bg-red-50/);
+  await expect(
+    customAlert.getByRole("heading", { level: 5, name: "Action required" }),
+  ).toBeVisible();
+  await expect(customAlert).toContainText(
+    "Custom class names should be preserved with danger styling.",
   );
 });

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -196,6 +196,16 @@ const AlertShowcase = () => {
             Your profile settings were stored successfully.
           </AlertDescription>
         </Alert>
+        <Alert
+          status="danger"
+          className="alert-custom-frame"
+          data-testid="alert-custom"
+        >
+          <AlertTitle>Action required</AlertTitle>
+          <AlertDescription>
+            Custom class names should be preserved with danger styling.
+          </AlertDescription>
+        </Alert>
       </div>
     </Section>
   );

--- a/registry.json
+++ b/registry.json
@@ -48,7 +48,7 @@
     "alert": {
       "type": "file",
       "name": "Alert.tsx",
-      "checksum": "990217920bbadd3c7efe73b67d90da523f10aed92c7c18c5f7d7456de6bc1a91"
+      "checksum": "6f5687b2846f901452dc874f4db54c83e7d148edb291cd6185760777be25f8f6"
     },
     "avatar": {
       "type": "file",


### PR DESCRIPTION
## Summary
- preserve consumer `className` on `Alert` while keeping variant styling intact
- add a harness case plus Playwright coverage for a custom class merged with the danger variant
- refresh `registry.json` checksums for the Alert component change

## Validation
- bun install
- bun run registry:checksums
- bun --filter react test:e2e tests/alert.spec.ts
- bun run react:build

@p-sw