### PR TITLE
chore(registry): regenerate select checksum

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -146,7 +146,7 @@
     "select": {
       "type": "file",
       "name": "Select.tsx",
-      "checksum": "9f962b65cd18fb91e32ef21038f0d6b3b8f8fb5c6627a677192bc18c9e18daab"
+      "checksum": "42a9ad9085581a358b1bbff5dbdb35543dfec4d60919e46f50d554577cb0175e"
     },
     "separator": {
       "type": "file",


### PR DESCRIPTION
Regenerates the Select entry checksum after the component icon update.

@p-sw