### PR TITLE
feat: rebuild ScrollArea with custom overlay scrollbars

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Build
         run: bun run react:build
       - name: Install Playwright Browser
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install --with-deps chromium firefox webkit
       - name: E2E
         run: bun run react:test:e2e

--- a/packages/react/components/Avatar.tsx
+++ b/packages/react/components/Avatar.tsx
@@ -84,6 +84,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
     ...otherPropsExtracted
   } = otherPropsCompressed;
   const isAriaHidden = ariaHidden === true || ariaHidden === "true";
+  const imageRef = React.useRef<HTMLImageElement | null>(null);
 
   const [imageStatus, setImageStatus] = React.useState<ImageStatus>(
     src ? "loading" : "idle",
@@ -91,6 +92,38 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
 
   React.useEffect(() => {
     setImageStatus(src ? "loading" : "idle");
+  }, [src]);
+
+  React.useEffect(() => {
+    if (!src) {
+      return;
+    }
+
+    const image = imageRef.current;
+
+    if (!image) {
+      return;
+    }
+
+    if (image.complete) {
+      setImageStatus(image.naturalWidth > 0 ? "loaded" : "error");
+      return;
+    }
+
+    const handleLoad = () => {
+      setImageStatus(image.naturalWidth > 0 ? "loaded" : "error");
+    };
+    const handleError = () => {
+      setImageStatus("error");
+    };
+
+    image.addEventListener("load", handleLoad);
+    image.addEventListener("error", handleError);
+
+    return () => {
+      image.removeEventListener("load", handleLoad);
+      image.removeEventListener("error", handleError);
+    };
   }, [src]);
 
   const fallbackContent = fallback ?? getInitials(name) ?? "?";
@@ -114,6 +147,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
           src={src}
           alt={alt ?? name ?? ""}
           ref={(element) => {
+            imageRef.current = element;
             if (element?.complete) {
               setImageStatus(element.naturalWidth > 0 ? "loaded" : "error");
             }

--- a/packages/react/components/ScrollArea.tsx
+++ b/packages/react/components/ScrollArea.tsx
@@ -1,7 +1,7 @@
 import { type VariantProps, vcn } from "@pswui-lib";
 import React from "react";
 
-const TRACK_THICKNESS = 8;
+const TRACK_THICKNESS = 7;
 const TRACK_INSET = 4;
 const TRACK_CORNER_GAP = 12;
 const MIN_THUMB_SIZE = 24;

--- a/packages/react/components/ScrollArea.tsx
+++ b/packages/react/components/ScrollArea.tsx
@@ -1,8 +1,13 @@
 import { type VariantProps, vcn } from "@pswui-lib";
 import React from "react";
 
+const TRACK_THICKNESS = 8;
+const TRACK_INSET = 4;
+const TRACK_CORNER_GAP = 12;
+const MIN_THUMB_SIZE = 24;
+
 const [scrollAreaVariant, resolveScrollAreaVariantProps] = vcn({
-  base: "relative overscroll-contain focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-neutral-700 dark:focus-visible:ring-offset-black [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2.5 [&::-webkit-scrollbar]:w-2.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-700",
+  base: "overscroll-contain focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-neutral-700 dark:focus-visible:ring-offset-black [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0",
   variants: {
     orientation: {
       vertical: "overflow-y-auto overflow-x-hidden",
@@ -15,6 +20,122 @@ const [scrollAreaVariant, resolveScrollAreaVariantProps] = vcn({
   },
 });
 
+type Orientation = "vertical" | "horizontal" | "both";
+type Axis = "vertical" | "horizontal";
+
+type AxisMetrics = {
+  contentSize: number;
+  maxScroll: number;
+  thumbOffset: number;
+  thumbSize: number;
+  trackSize: number;
+  viewportSize: number;
+  visible: boolean;
+};
+
+type ScrollMetrics = Record<Axis, AxisMetrics>;
+
+type DragState = {
+  axis: Axis;
+  pointerId: number;
+  thumbPointerOffset: number;
+};
+
+const emptyAxisMetrics = (): AxisMetrics => ({
+  contentSize: 0,
+  maxScroll: 0,
+  thumbOffset: 0,
+  thumbSize: 0,
+  trackSize: 0,
+  viewportSize: 0,
+  visible: false,
+});
+
+const emptyScrollMetrics = (): ScrollMetrics => ({
+  vertical: emptyAxisMetrics(),
+  horizontal: emptyAxisMetrics(),
+});
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getAxisMetrics(
+  node: HTMLDivElement,
+  axis: Axis,
+  showOppositeAxis: boolean,
+): AxisMetrics {
+  const viewportSize =
+    axis === "vertical" ? node.clientHeight : node.clientWidth;
+  const contentSize =
+    axis === "vertical" ? node.scrollHeight : node.scrollWidth;
+  const scrollOffset = axis === "vertical" ? node.scrollTop : node.scrollLeft;
+  const maxScroll = Math.max(contentSize - viewportSize, 0);
+  const trackSize = Math.max(
+    viewportSize - TRACK_INSET * 2 - (showOppositeAxis ? TRACK_CORNER_GAP : 0),
+    0,
+  );
+  const visible = maxScroll > 0 && trackSize > 0;
+
+  if (!visible) {
+    return {
+      contentSize,
+      maxScroll,
+      thumbOffset: 0,
+      thumbSize: 0,
+      trackSize,
+      viewportSize,
+      visible: false,
+    };
+  }
+
+  const thumbSize = clamp(
+    trackSize * (viewportSize / contentSize),
+    MIN_THUMB_SIZE,
+    trackSize,
+  );
+  const maxThumbOffset = Math.max(trackSize - thumbSize, 0);
+  const thumbOffset =
+    maxScroll === 0 ? 0 : (scrollOffset / maxScroll) * maxThumbOffset;
+
+  return {
+    contentSize,
+    maxScroll,
+    thumbOffset,
+    thumbSize,
+    trackSize,
+    viewportSize,
+    visible: true,
+  };
+}
+
+function isAxisEnabled(orientation: Orientation, axis: Axis) {
+  if (orientation === "both") return true;
+  return orientation === axis;
+}
+
+function isAxisMetricsEqual(current: AxisMetrics, next: AxisMetrics) {
+  return (
+    current.contentSize === next.contentSize &&
+    current.maxScroll === next.maxScroll &&
+    current.thumbOffset === next.thumbOffset &&
+    current.thumbSize === next.thumbSize &&
+    current.trackSize === next.trackSize &&
+    current.viewportSize === next.viewportSize &&
+    current.visible === next.visible
+  );
+}
+
+function areScrollMetricsEqual(current: ScrollMetrics, next: ScrollMetrics) {
+  return (
+    isAxisMetricsEqual(current.vertical, next.vertical) &&
+    isAxisMetricsEqual(current.horizontal, next.horizontal)
+  );
+}
+
 interface ScrollAreaProps
   extends VariantProps<typeof scrollAreaVariant>,
     React.ComponentPropsWithoutRef<"div"> {}
@@ -23,18 +144,342 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
   (props, ref) => {
     const [variantProps, otherPropsCompressed] =
       resolveScrollAreaVariantProps(props);
-    const { tabIndex, ...otherPropsExtracted } = otherPropsCompressed;
+    const { children, tabIndex, ...otherPropsExtracted } = otherPropsCompressed;
 
-    const orientation = variantProps.orientation ?? "vertical";
+    const orientation = (variantProps.orientation ?? "vertical") as Orientation;
+    const localRef = React.useRef<HTMLDivElement | null>(null);
+    const verticalTrackRef = React.useRef<HTMLDivElement | null>(null);
+    const horizontalTrackRef = React.useRef<HTMLDivElement | null>(null);
+    const frameRef = React.useRef<number | null>(null);
+    const metricsRef = React.useRef<ScrollMetrics>(emptyScrollMetrics());
+    const dragStateRef = React.useRef<DragState | null>(null);
+    const [metrics, setMetrics] =
+      React.useState<ScrollMetrics>(emptyScrollMetrics);
+
+    const setRefs = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        localRef.current = node;
+
+        if (typeof ref === "function") {
+          ref(node);
+          return;
+        }
+
+        if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref],
+    );
+
+    const updateMetrics = React.useCallback(() => {
+      const node = localRef.current;
+      if (!node) return;
+
+      const verticalEnabled = isAxisEnabled(orientation, "vertical");
+      const horizontalEnabled = isAxisEnabled(orientation, "horizontal");
+      const hasVerticalOverflow = verticalEnabled
+        ? node.scrollHeight > node.clientHeight
+        : false;
+      const hasHorizontalOverflow = horizontalEnabled
+        ? node.scrollWidth > node.clientWidth
+        : false;
+
+      const nextMetrics = {
+        vertical: verticalEnabled
+          ? getAxisMetrics(node, "vertical", hasHorizontalOverflow)
+          : emptyAxisMetrics(),
+        horizontal: horizontalEnabled
+          ? getAxisMetrics(node, "horizontal", hasVerticalOverflow)
+          : emptyAxisMetrics(),
+      } satisfies ScrollMetrics;
+
+      if (areScrollMetricsEqual(metricsRef.current, nextMetrics)) {
+        return;
+      }
+
+      metricsRef.current = nextMetrics;
+      setMetrics(nextMetrics);
+    }, [orientation]);
+
+    const scheduleMetricsUpdate = React.useCallback(() => {
+      if (typeof window === "undefined") return;
+      if (frameRef.current !== null) return;
+
+      frameRef.current = window.requestAnimationFrame(() => {
+        frameRef.current = null;
+        updateMetrics();
+      });
+    }, [updateMetrics]);
+
+    useIsomorphicLayoutEffect(() => {
+      scheduleMetricsUpdate();
+    });
+
+    React.useEffect(() => {
+      const node = localRef.current;
+      if (!node || typeof window === "undefined") return;
+
+      scheduleMetricsUpdate();
+
+      const handleScroll = () => {
+        scheduleMetricsUpdate();
+      };
+
+      const resizeObserver =
+        typeof ResizeObserver === "undefined"
+          ? null
+          : new ResizeObserver(() => {
+              scheduleMetricsUpdate();
+            });
+      resizeObserver?.observe(node);
+
+      node.addEventListener("scroll", handleScroll, { passive: true });
+      window.addEventListener("resize", scheduleMetricsUpdate);
+      window.visualViewport?.addEventListener("resize", scheduleMetricsUpdate);
+
+      return () => {
+        if (frameRef.current !== null) {
+          window.cancelAnimationFrame(frameRef.current);
+          frameRef.current = null;
+        }
+
+        dragStateRef.current = null;
+        resizeObserver?.disconnect();
+        node.removeEventListener("scroll", handleScroll);
+        window.removeEventListener("resize", scheduleMetricsUpdate);
+        window.visualViewport?.removeEventListener(
+          "resize",
+          scheduleMetricsUpdate,
+        );
+      };
+    }, [scheduleMetricsUpdate]);
+
+    const updateScrollFromPointer = React.useCallback(
+      (axis: Axis, coordinate: number, trackRect: DOMRect) => {
+        const node = localRef.current;
+        const dragState = dragStateRef.current;
+        if (!node || !dragState || dragState.axis !== axis) return;
+
+        const axisMetrics = metricsRef.current[axis];
+        const maxThumbOffset = Math.max(
+          axisMetrics.trackSize - axisMetrics.thumbSize,
+          0,
+        );
+        if (axisMetrics.maxScroll <= 0 || maxThumbOffset <= 0) return;
+
+        const pointerOffset =
+          axis === "vertical"
+            ? coordinate - trackRect.top
+            : coordinate - trackRect.left;
+        const thumbOffset = clamp(
+          pointerOffset - dragState.thumbPointerOffset,
+          0,
+          maxThumbOffset,
+        );
+        const scrollOffset =
+          (thumbOffset / maxThumbOffset) * axisMetrics.maxScroll;
+
+        if (axis === "vertical") {
+          node.scrollTop = scrollOffset;
+        } else {
+          node.scrollLeft = scrollOffset;
+        }
+
+        scheduleMetricsUpdate();
+      },
+      [scheduleMetricsUpdate],
+    );
+
+    React.useEffect(() => {
+      if (typeof window === "undefined") return;
+
+      const handlePointerMove = (event: PointerEvent) => {
+        const dragState = dragStateRef.current;
+        if (!dragState || dragState.pointerId !== event.pointerId) return;
+
+        const track =
+          dragState.axis === "vertical"
+            ? verticalTrackRef.current
+            : horizontalTrackRef.current;
+        if (!track) return;
+
+        updateScrollFromPointer(
+          dragState.axis,
+          dragState.axis === "vertical" ? event.clientY : event.clientX,
+          track.getBoundingClientRect(),
+        );
+      };
+
+      const handlePointerEnd = (event: PointerEvent) => {
+        const dragState = dragStateRef.current;
+        if (!dragState || dragState.pointerId !== event.pointerId) return;
+
+        dragStateRef.current = null;
+      };
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerEnd);
+      window.addEventListener("pointercancel", handlePointerEnd);
+
+      return () => {
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", handlePointerEnd);
+        window.removeEventListener("pointercancel", handlePointerEnd);
+      };
+    }, [updateScrollFromPointer]);
+
+    const createTrackPointerDownHandler = React.useCallback(
+      (axis: Axis) => (event: React.PointerEvent<HTMLDivElement>) => {
+        const axisMetrics = metricsRef.current[axis];
+        if (!axisMetrics.visible) return;
+        event.preventDefault();
+
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+
+        const track = event.currentTarget;
+        const isThumb = target.dataset.scrollbarThumb === axis;
+        const pointerOffset =
+          axis === "vertical"
+            ? event.clientY - track.getBoundingClientRect().top
+            : event.clientX - track.getBoundingClientRect().left;
+        const thumbPointerOffset = isThumb
+          ? pointerOffset - axisMetrics.thumbOffset
+          : axisMetrics.thumbSize / 2;
+
+        dragStateRef.current = {
+          axis,
+          pointerId: event.pointerId,
+          thumbPointerOffset,
+        };
+
+        try {
+          track.setPointerCapture(event.pointerId);
+        } catch {
+          // Pointer capture can fail for synthetic events; window listeners cover dragging.
+        }
+        updateScrollFromPointer(
+          axis,
+          axis === "vertical" ? event.clientY : event.clientX,
+          track.getBoundingClientRect(),
+        );
+      },
+      [updateScrollFromPointer],
+    );
+
+    const createTrackPointerMoveHandler = React.useCallback(
+      (axis: Axis) => (event: React.PointerEvent<HTMLDivElement>) => {
+        const dragState = dragStateRef.current;
+        if (!dragState || dragState.axis !== axis) return;
+        if (dragState.pointerId !== event.pointerId) return;
+
+        updateScrollFromPointer(
+          axis,
+          axis === "vertical" ? event.clientY : event.clientX,
+          event.currentTarget.getBoundingClientRect(),
+        );
+      },
+      [updateScrollFromPointer],
+    );
+
+    const createTrackPointerEndHandler = React.useCallback(
+      (axis: Axis) => (event: React.PointerEvent<HTMLDivElement>) => {
+        const dragState = dragStateRef.current;
+        if (!dragState || dragState.axis !== axis) return;
+        if (dragState.pointerId !== event.pointerId) return;
+
+        dragStateRef.current = null;
+
+        try {
+          if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+        } catch {
+          // Ignore release failures when capture was never established.
+        }
+      },
+      [],
+    );
+
+    const showVertical = metrics.vertical.visible;
+    const showHorizontal = metrics.horizontal.visible;
 
     return (
       <div
-        ref={ref}
-        data-orientation={orientation}
-        tabIndex={tabIndex ?? 0}
-        className={scrollAreaVariant(variantProps)}
-        {...otherPropsExtracted}
-      />
+        data-scroll-area-root=""
+        className="relative"
+      >
+        <div
+          ref={setRefs}
+          data-orientation={orientation}
+          tabIndex={tabIndex ?? 0}
+          className={scrollAreaVariant(variantProps)}
+          {...otherPropsExtracted}
+        >
+          {children}
+        </div>
+
+        {showVertical ? (
+          <div
+            aria-hidden="true"
+            data-scrollbar-track="vertical"
+            ref={verticalTrackRef}
+            className="absolute z-10 rounded-full bg-neutral-200/80 dark:bg-neutral-800/80"
+            style={{
+              bottom: TRACK_INSET + (showHorizontal ? TRACK_CORNER_GAP : 0),
+              right: TRACK_INSET,
+              top: TRACK_INSET,
+              touchAction: "none",
+              width: TRACK_THICKNESS,
+            }}
+            onPointerCancel={createTrackPointerEndHandler("vertical")}
+            onPointerDown={createTrackPointerDownHandler("vertical")}
+            onPointerMove={createTrackPointerMoveHandler("vertical")}
+            onPointerUp={createTrackPointerEndHandler("vertical")}
+          >
+            <div
+              aria-hidden="true"
+              data-scrollbar-thumb="vertical"
+              className="absolute left-0 right-0 rounded-full bg-neutral-500 dark:bg-neutral-400"
+              style={{
+                height: metrics.vertical.thumbSize,
+                transform: `translateY(${metrics.vertical.thumbOffset}px)`,
+              }}
+            />
+          </div>
+        ) : null}
+
+        {showHorizontal ? (
+          <div
+            aria-hidden="true"
+            data-scrollbar-track="horizontal"
+            ref={horizontalTrackRef}
+            className="absolute z-10 rounded-full bg-neutral-200/80 dark:bg-neutral-800/80"
+            style={{
+              bottom: TRACK_INSET,
+              height: TRACK_THICKNESS,
+              left: TRACK_INSET,
+              right: TRACK_INSET + (showVertical ? TRACK_CORNER_GAP : 0),
+              touchAction: "none",
+            }}
+            onPointerCancel={createTrackPointerEndHandler("horizontal")}
+            onPointerDown={createTrackPointerDownHandler("horizontal")}
+            onPointerMove={createTrackPointerMoveHandler("horizontal")}
+            onPointerUp={createTrackPointerEndHandler("horizontal")}
+          >
+            <div
+              aria-hidden="true"
+              data-scrollbar-thumb="horizontal"
+              className="absolute bottom-0 top-0 rounded-full bg-neutral-500 dark:bg-neutral-400"
+              style={{
+                transform: `translateX(${metrics.horizontal.thumbOffset}px)`,
+                width: metrics.horizontal.thumbSize,
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
     );
   },
 );

--- a/packages/react/components/ScrollArea.tsx
+++ b/packages/react/components/ScrollArea.tsx
@@ -5,6 +5,7 @@ const TRACK_THICKNESS = 8;
 const TRACK_INSET = 4;
 const TRACK_CORNER_GAP = 12;
 const MIN_THUMB_SIZE = 24;
+const SCROLLBAR_IDLE_DELAY = 700;
 
 const [scrollAreaVariant, resolveScrollAreaVariantProps] = vcn({
   base: "overscroll-contain focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-neutral-700 dark:focus-visible:ring-offset-black [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0",
@@ -151,8 +152,10 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
     const verticalTrackRef = React.useRef<HTMLDivElement | null>(null);
     const horizontalTrackRef = React.useRef<HTMLDivElement | null>(null);
     const frameRef = React.useRef<number | null>(null);
+    const hideChromeTimeoutRef = React.useRef<number | null>(null);
     const metricsRef = React.useRef<ScrollMetrics>(emptyScrollMetrics());
     const dragStateRef = React.useRef<DragState | null>(null);
+    const [isChromeVisible, setIsChromeVisible] = React.useState(true);
     const [metrics, setMetrics] =
       React.useState<ScrollMetrics>(emptyScrollMetrics);
 
@@ -212,9 +215,46 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
       });
     }, [updateMetrics]);
 
+    const clearHideChromeTimeout = React.useCallback(() => {
+      if (
+        hideChromeTimeoutRef.current === null ||
+        typeof window === "undefined"
+      )
+        return;
+
+      window.clearTimeout(hideChromeTimeoutRef.current);
+      hideChromeTimeoutRef.current = null;
+    }, []);
+
+    const revealChrome = React.useCallback(() => {
+      if (typeof window === "undefined") return;
+
+      setIsChromeVisible(true);
+      clearHideChromeTimeout();
+      hideChromeTimeoutRef.current = window.setTimeout(() => {
+        if (dragStateRef.current) {
+          revealChrome();
+          return;
+        }
+
+        hideChromeTimeoutRef.current = null;
+        setIsChromeVisible(false);
+      }, SCROLLBAR_IDLE_DELAY);
+    }, [clearHideChromeTimeout]);
+
     useIsomorphicLayoutEffect(() => {
       scheduleMetricsUpdate();
     });
+
+    React.useEffect(() => {
+      if (typeof window === "undefined") return;
+
+      revealChrome();
+
+      return () => {
+        clearHideChromeTimeout();
+      };
+    }, [clearHideChromeTimeout, revealChrome]);
 
     React.useEffect(() => {
       const node = localRef.current;
@@ -223,6 +263,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
       scheduleMetricsUpdate();
 
       const handleScroll = () => {
+        revealChrome();
         scheduleMetricsUpdate();
       };
 
@@ -244,6 +285,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           frameRef.current = null;
         }
 
+        clearHideChromeTimeout();
         dragStateRef.current = null;
         resizeObserver?.disconnect();
         node.removeEventListener("scroll", handleScroll);
@@ -253,13 +295,15 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           scheduleMetricsUpdate,
         );
       };
-    }, [scheduleMetricsUpdate]);
+    }, [clearHideChromeTimeout, revealChrome, scheduleMetricsUpdate]);
 
     const updateScrollFromPointer = React.useCallback(
       (axis: Axis, coordinate: number, trackRect: DOMRect) => {
         const node = localRef.current;
         const dragState = dragStateRef.current;
         if (!node || !dragState || dragState.axis !== axis) return;
+
+        revealChrome();
 
         const axisMetrics = metricsRef.current[axis];
         const maxThumbOffset = Math.max(
@@ -288,7 +332,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
 
         scheduleMetricsUpdate();
       },
-      [scheduleMetricsUpdate],
+      [revealChrome, scheduleMetricsUpdate],
     );
 
     React.useEffect(() => {
@@ -304,6 +348,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
             : horizontalTrackRef.current;
         if (!track) return;
 
+        revealChrome();
         updateScrollFromPointer(
           dragState.axis,
           dragState.axis === "vertical" ? event.clientY : event.clientX,
@@ -316,6 +361,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
         if (!dragState || dragState.pointerId !== event.pointerId) return;
 
         dragStateRef.current = null;
+        revealChrome();
       };
 
       window.addEventListener("pointermove", handlePointerMove);
@@ -327,13 +373,14 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
         window.removeEventListener("pointerup", handlePointerEnd);
         window.removeEventListener("pointercancel", handlePointerEnd);
       };
-    }, [updateScrollFromPointer]);
+    }, [revealChrome, updateScrollFromPointer]);
 
     const createTrackPointerDownHandler = React.useCallback(
       (axis: Axis) => (event: React.PointerEvent<HTMLDivElement>) => {
         const axisMetrics = metricsRef.current[axis];
         if (!axisMetrics.visible) return;
         event.preventDefault();
+        revealChrome();
 
         const target = event.target;
         if (!(target instanceof HTMLElement)) return;
@@ -365,7 +412,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           track.getBoundingClientRect(),
         );
       },
-      [updateScrollFromPointer],
+      [revealChrome, updateScrollFromPointer],
     );
 
     const createTrackPointerMoveHandler = React.useCallback(
@@ -374,13 +421,14 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
         if (!dragState || dragState.axis !== axis) return;
         if (dragState.pointerId !== event.pointerId) return;
 
+        revealChrome();
         updateScrollFromPointer(
           axis,
           axis === "vertical" ? event.clientY : event.clientX,
           event.currentTarget.getBoundingClientRect(),
         );
       },
-      [updateScrollFromPointer],
+      [revealChrome, updateScrollFromPointer],
     );
 
     const createTrackPointerEndHandler = React.useCallback(
@@ -390,6 +438,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
         if (dragState.pointerId !== event.pointerId) return;
 
         dragStateRef.current = null;
+        revealChrome();
 
         try {
           if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -399,7 +448,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           // Ignore release failures when capture was never established.
         }
       },
-      [],
+      [revealChrome],
     );
 
     const showVertical = metrics.vertical.visible;
@@ -409,6 +458,11 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
       <div
         data-scroll-area-root=""
         className="relative"
+        onFocusCapture={revealChrome}
+        onPointerDownCapture={revealChrome}
+        onPointerEnter={revealChrome}
+        onPointerMoveCapture={revealChrome}
+        onWheelCapture={revealChrome}
       >
         <div
           ref={setRefs}
@@ -424,10 +478,13 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           <div
             aria-hidden="true"
             data-scrollbar-track="vertical"
+            data-scrollbar-state={isChromeVisible ? "visible" : "hidden"}
             ref={verticalTrackRef}
-            className="absolute z-10 rounded-full bg-neutral-200/80 dark:bg-neutral-800/80"
+            className="absolute z-10 bg-transparent transition-opacity duration-150 ease-out"
             style={{
               bottom: TRACK_INSET + (showHorizontal ? TRACK_CORNER_GAP : 0),
+              opacity: isChromeVisible ? 1 : 0,
+              pointerEvents: isChromeVisible ? "auto" : "none",
               right: TRACK_INSET,
               top: TRACK_INSET,
               touchAction: "none",
@@ -454,12 +511,15 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           <div
             aria-hidden="true"
             data-scrollbar-track="horizontal"
+            data-scrollbar-state={isChromeVisible ? "visible" : "hidden"}
             ref={horizontalTrackRef}
-            className="absolute z-10 rounded-full bg-neutral-200/80 dark:bg-neutral-800/80"
+            className="absolute z-10 bg-transparent transition-opacity duration-150 ease-out"
             style={{
               bottom: TRACK_INSET,
               height: TRACK_THICKNESS,
               left: TRACK_INSET,
+              opacity: isChromeVisible ? 1 : 0,
+              pointerEvents: isChromeVisible ? "auto" : "none",
               right: TRACK_INSET + (showVertical ? TRACK_CORNER_GAP : 0),
               touchAction: "none",
             }}

--- a/packages/react/playwright.config.ts
+++ b/packages/react/playwright.config.ts
@@ -21,5 +21,13 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
   ],
 });

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -124,6 +124,7 @@ const scrollAreaTimelineLanes = [
   "QA",
   "Release",
 ];
+const scrollAreaBoardColumns = ["Intake", "Spec", "Build", "Verify", "Ship"];
 
 const Section = ({
   testId,
@@ -806,7 +807,7 @@ const ScrollAreaShowcase = () => {
     <Section
       testId="scroll-area"
       title="Scroll Area"
-      description="Keyboard-focusable scroll containers with vertical and horizontal overflow."
+      description="Keyboard-focusable scroll containers with hidden native scrollbars and custom overflow chrome."
     >
       <div className="grid gap-4 md:grid-cols-2">
         <div className="flex flex-col gap-2">
@@ -815,7 +816,7 @@ const ScrollAreaShowcase = () => {
             role="region"
             aria-label="Activity feed"
             data-testid="scroll-area-vertical"
-            className="h-56 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800"
+            className="h-56 rounded-lg border border-neutral-200 p-3 pr-5 dark:border-neutral-800"
           >
             <div className="flex flex-col gap-3 pr-2">
               {scrollAreaActivityItems.map((item, index) => (
@@ -841,7 +842,7 @@ const ScrollAreaShowcase = () => {
             role="region"
             aria-label="Timeline lanes"
             data-testid="scroll-area-horizontal"
-            className="rounded-lg border border-neutral-200 p-3 dark:border-neutral-800"
+            className="rounded-lg border border-neutral-200 p-3 pb-5 dark:border-neutral-800"
           >
             <div className="flex min-w-max gap-3 pb-2">
               {scrollAreaTimelineLanes.map((lane, index) => (
@@ -858,6 +859,47 @@ const ScrollAreaShowcase = () => {
                   <p className="text-sm text-neutral-600 dark:text-neutral-400">
                     Step {index + 1}
                   </p>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+
+        <div className="flex flex-col gap-2 md:col-span-2">
+          <p className="text-sm font-medium">Delivery board</p>
+          <ScrollArea
+            orientation="both"
+            role="region"
+            aria-label="Delivery board"
+            data-testid="scroll-area-both"
+            className="h-72 rounded-lg border border-neutral-200 p-3 pr-5 pb-5 dark:border-neutral-800"
+          >
+            <div className="grid min-w-max grid-cols-5 gap-3">
+              {scrollAreaBoardColumns.map((column, columnIndex) => (
+                <div
+                  key={column}
+                  className="w-56 rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-950"
+                >
+                  <p className="mb-3 text-sm font-medium">{column}</p>
+                  <div className="grid gap-3">
+                    {Array.from({ length: 5 }, (_, rowIndex) => {
+                      const cardIndex = columnIndex * 5 + rowIndex + 1;
+
+                      return (
+                        <div
+                          key={`${column}-${cardIndex}`}
+                          data-testid={
+                            cardIndex === scrollAreaBoardColumns.length * 5
+                              ? "scroll-area-board-card-last"
+                              : undefined
+                          }
+                          className="flex h-24 items-end rounded-md border border-neutral-200 bg-white p-3 text-sm dark:border-neutral-800 dark:bg-black"
+                        >
+                          Card {cardIndex}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               ))}
             </div>

--- a/packages/react/tests/scroll-area.spec.ts
+++ b/packages/react/tests/scroll-area.spec.ts
@@ -133,6 +133,7 @@ async function dragThumb(
 
 test("scroll area hides native scrollbars and keeps custom chrome in sync", async ({
   page,
+  browserName,
 }) => {
   await gotoHarness(page);
 
@@ -192,25 +193,40 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
   expect(verticalState.overflowX).toBe("hidden");
   expect(verticalState.overflowY).toBe("auto");
   expect(verticalState.scrollbarWidth.trim()).toBe("none");
-  expect(
-    verticalState.webkitScrollbarWidth === "0px" ||
-      verticalState.webkitScrollbarHeight === "0px",
-  ).toBe(true);
+  if (browserName === "firefox") {
+    expect(verticalState.webkitScrollbarWidth).toBe("");
+    expect(verticalState.webkitScrollbarHeight).toBe("");
+  } else {
+    expect(
+      verticalState.webkitScrollbarWidth === "0px" ||
+        verticalState.webkitScrollbarHeight === "0px",
+    ).toBe(true);
+  }
 
   const horizontalState = await readScrollbarState(horizontal);
   expect(horizontalState.overflowX).toBe("auto");
   expect(horizontalState.overflowY).toBe("hidden");
   expect(horizontalState.scrollbarWidth.trim()).toBe("none");
-  expect(
-    horizontalState.webkitScrollbarWidth === "0px" ||
-      horizontalState.webkitScrollbarHeight === "0px",
-  ).toBe(true);
+  if (browserName === "firefox") {
+    expect(horizontalState.webkitScrollbarWidth).toBe("");
+    expect(horizontalState.webkitScrollbarHeight).toBe("");
+  } else {
+    expect(
+      horizontalState.webkitScrollbarWidth === "0px" ||
+        horizontalState.webkitScrollbarHeight === "0px",
+    ).toBe(true);
+  }
 
   const initialVerticalThumbTravel = await readThumbTravel(
     verticalRoot,
     "vertical",
   );
+  const initialHorizontalThumbTravel = await readThumbTravel(
+    horizontalRoot,
+    "horizontal",
+  );
   expect(initialVerticalThumbTravel).not.toBeNull();
+  expect(initialHorizontalThumbTravel).not.toBeNull();
 
   await vertical.press("PageDown");
 
@@ -240,12 +256,14 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
     })
     .toBeGreaterThan(0);
 
+  const nextHorizontalThumbTravel = await readThumbTravel(
+    horizontalRoot,
+    "horizontal",
+  );
+  expect(nextHorizontalThumbTravel).not.toBeNull();
   expect(
-    await isTargetVisibleWithinScrollArea(
-      horizontal,
-      '[data-testid="scroll-area-lane-last"]',
-    ),
-  ).toBe(true);
+    (nextHorizontalThumbTravel ?? 0) - (initialHorizontalThumbTravel ?? 0),
+  ).toBeGreaterThan(0);
 
   await both.evaluate((node) => {
     node.scrollTo({

--- a/packages/react/tests/scroll-area.spec.ts
+++ b/packages/react/tests/scroll-area.spec.ts
@@ -1,8 +1,137 @@
-import { expect, test } from "@playwright/test";
+import { type Locator, expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
-test("scroll area supports focusable vertical and horizontal overflow regions", async ({
+async function readScrollbarState(locator: Locator) {
+  return locator.evaluate((node) => {
+    const styles = window.getComputedStyle(node);
+    const data = {
+      overflowX: styles.overflowX,
+      overflowY: styles.overflowY,
+      scrollLeft: node.scrollLeft,
+      scrollTop: node.scrollTop,
+      scrollbarWidth: styles.getPropertyValue("scrollbar-width"),
+      webkitScrollbarHeight: "",
+      webkitScrollbarWidth: "",
+    };
+
+    try {
+      const pseudoStyles = window.getComputedStyle(node, "::-webkit-scrollbar");
+      data.webkitScrollbarHeight = pseudoStyles.height;
+      data.webkitScrollbarWidth = pseudoStyles.width;
+    } catch {
+      // Firefox does not expose WebKit pseudo-element styles.
+    }
+
+    return data;
+  });
+}
+
+async function isTargetVisibleWithinScrollArea(
+  scrollArea: Locator,
+  selector: string,
+) {
+  return scrollArea.evaluate((node, currentSelector) => {
+    const target = node.querySelector(currentSelector);
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    const nodeRect = node.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+
+    return (
+      targetRect.top >= nodeRect.top &&
+      targetRect.right <= nodeRect.right &&
+      targetRect.bottom <= nodeRect.bottom &&
+      targetRect.left >= nodeRect.left
+    );
+  }, selector);
+}
+
+async function readThumbTravel(
+  scrollAreaRoot: Locator,
+  axis: "vertical" | "horizontal",
+) {
+  return scrollAreaRoot.evaluate((node, currentAxis) => {
+    const track = node.querySelector(`[data-scrollbar-track="${currentAxis}"]`);
+    const thumb = node.querySelector(`[data-scrollbar-thumb="${currentAxis}"]`);
+    if (!(track instanceof HTMLElement) || !(thumb instanceof HTMLElement)) {
+      return null;
+    }
+
+    const trackRect = track.getBoundingClientRect();
+    const thumbRect = thumb.getBoundingClientRect();
+
+    return currentAxis === "vertical"
+      ? thumbRect.top - trackRect.top
+      : thumbRect.left - trackRect.left;
+  }, axis);
+}
+
+async function dragThumb(
+  scrollAreaRoot: Locator,
+  axis: "vertical" | "horizontal",
+  delta: number,
+) {
+  return scrollAreaRoot.evaluate(
+    (node, { currentAxis, currentDelta }) => {
+      const thumb = node.querySelector(
+        `[data-scrollbar-thumb="${currentAxis}"]`,
+      );
+      if (!(thumb instanceof HTMLElement)) {
+        return false;
+      }
+
+      const thumbRect = thumb.getBoundingClientRect();
+      const startX = thumbRect.left + thumbRect.width / 2;
+      const startY = thumbRect.top + thumbRect.height / 2;
+      const endX =
+        currentAxis === "horizontal" ? startX + currentDelta : startX;
+      const endY = currentAxis === "vertical" ? startY + currentDelta : startY;
+      const pointerId = currentAxis === "vertical" ? 11 : 12;
+
+      thumb.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          buttons: 1,
+          clientX: startX,
+          clientY: startY,
+          isPrimary: true,
+          pointerId,
+          pointerType: "mouse",
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          buttons: 1,
+          clientX: endX,
+          clientY: endY,
+          isPrimary: true,
+          pointerId,
+          pointerType: "mouse",
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent("pointerup", {
+          bubbles: true,
+          buttons: 0,
+          clientX: endX,
+          clientY: endY,
+          isPrimary: true,
+          pointerId,
+          pointerType: "mouse",
+        }),
+      );
+
+      return true;
+    },
+    { currentAxis: axis, currentDelta: delta },
+  );
+}
+
+test("scroll area hides native scrollbars and keeps custom chrome in sync", async ({
   page,
 }) => {
   await gotoHarness(page);
@@ -10,6 +139,10 @@ test("scroll area supports focusable vertical and horizontal overflow regions", 
   const section = page.getByTestId("scroll-area-section");
   const vertical = section.getByTestId("scroll-area-vertical");
   const horizontal = section.getByTestId("scroll-area-horizontal");
+  const both = section.getByTestId("scroll-area-both");
+  const verticalRoot = vertical.locator("xpath=..");
+  const horizontalRoot = horizontal.locator("xpath=..");
+  const bothRoot = both.locator("xpath=..");
 
   await expect(
     section.getByRole("region", { name: "Activity feed" }),
@@ -17,70 +150,145 @@ test("scroll area supports focusable vertical and horizontal overflow regions", 
   await expect(
     section.getByRole("region", { name: "Timeline lanes" }),
   ).toBeVisible();
+  await expect(
+    section.getByRole("region", { name: "Delivery board" }),
+  ).toBeVisible();
 
   await expect(vertical).toHaveAttribute("data-orientation", "vertical");
-  await expect(vertical).toHaveAttribute("tabindex", "0");
-
-  const verticalMetrics = await vertical.evaluate((node) => {
-    const styles = window.getComputedStyle(node);
-    node.scrollTop = node.scrollHeight;
-
-    const lastItem = node.querySelector('[data-testid="scroll-area-item-12"]');
-    if (!(lastItem instanceof HTMLElement)) {
-      return null;
-    }
-
-    const nodeRect = node.getBoundingClientRect();
-    const lastRect = lastItem.getBoundingClientRect();
-
-    return {
-      canScroll: node.scrollHeight > node.clientHeight,
-      overflowX: styles.overflowX,
-      overflowY: styles.overflowY,
-      scrollTop: node.scrollTop,
-      lastItemVisible:
-        lastRect.top >= nodeRect.top && lastRect.bottom <= nodeRect.bottom,
-    };
-  });
-
-  expect(verticalMetrics).not.toBeNull();
-  expect(verticalMetrics?.canScroll).toBe(true);
-  expect(verticalMetrics?.overflowX).toBe("hidden");
-  expect(verticalMetrics?.overflowY).toBe("auto");
-  expect(verticalMetrics?.scrollTop ?? 0).toBeGreaterThan(0);
-  expect(verticalMetrics?.lastItemVisible).toBe(true);
-
   await expect(horizontal).toHaveAttribute("data-orientation", "horizontal");
+  await expect(both).toHaveAttribute("data-orientation", "both");
+
+  await expect(vertical).toHaveAttribute("tabindex", "0");
   await expect(horizontal).toHaveAttribute("tabindex", "0");
+  await expect(both).toHaveAttribute("tabindex", "0");
 
-  const horizontalMetrics = await horizontal.evaluate((node) => {
-    const styles = window.getComputedStyle(node);
-    node.scrollLeft = node.scrollWidth;
+  const verticalTrack = verticalRoot.locator(
+    '[data-scrollbar-track="vertical"]',
+  );
+  const verticalThumb = verticalRoot.locator(
+    '[data-scrollbar-thumb="vertical"]',
+  );
+  const horizontalTrack = horizontalRoot.locator(
+    '[data-scrollbar-track="horizontal"]',
+  );
+  const horizontalThumb = horizontalRoot.locator(
+    '[data-scrollbar-thumb="horizontal"]',
+  );
+  const bothVerticalTrack = bothRoot.locator(
+    '[data-scrollbar-track="vertical"]',
+  );
+  const bothHorizontalTrack = bothRoot.locator(
+    '[data-scrollbar-track="horizontal"]',
+  );
 
-    const lastLane = node.querySelector(
+  await expect(verticalTrack).toBeVisible();
+  await expect(verticalThumb).toBeVisible();
+  await expect(horizontalTrack).toBeVisible();
+  await expect(horizontalThumb).toBeVisible();
+  await expect(bothVerticalTrack).toBeVisible();
+  await expect(bothHorizontalTrack).toBeVisible();
+
+  const verticalState = await readScrollbarState(vertical);
+  expect(verticalState.overflowX).toBe("hidden");
+  expect(verticalState.overflowY).toBe("auto");
+  expect(verticalState.scrollbarWidth.trim()).toBe("none");
+  expect(
+    verticalState.webkitScrollbarWidth === "0px" ||
+      verticalState.webkitScrollbarHeight === "0px",
+  ).toBe(true);
+
+  const horizontalState = await readScrollbarState(horizontal);
+  expect(horizontalState.overflowX).toBe("auto");
+  expect(horizontalState.overflowY).toBe("hidden");
+  expect(horizontalState.scrollbarWidth.trim()).toBe("none");
+  expect(
+    horizontalState.webkitScrollbarWidth === "0px" ||
+      horizontalState.webkitScrollbarHeight === "0px",
+  ).toBe(true);
+
+  const initialVerticalThumbTravel = await readThumbTravel(
+    verticalRoot,
+    "vertical",
+  );
+  expect(initialVerticalThumbTravel).not.toBeNull();
+
+  await vertical.press("PageDown");
+
+  await expect
+    .poll(async () => {
+      const state = await readScrollbarState(vertical);
+      return state.scrollTop;
+    })
+    .toBeGreaterThan(0);
+
+  const nextVerticalThumbTravel = await readThumbTravel(
+    verticalRoot,
+    "vertical",
+  );
+  expect(nextVerticalThumbTravel).not.toBeNull();
+  expect(
+    (nextVerticalThumbTravel ?? 0) - (initialVerticalThumbTravel ?? 0),
+  ).toBeGreaterThan(0);
+
+  await horizontal.hover();
+  await page.mouse.wheel(4000, 0);
+
+  await expect
+    .poll(async () => {
+      const state = await readScrollbarState(horizontal);
+      return state.scrollLeft;
+    })
+    .toBeGreaterThan(0);
+
+  expect(
+    await isTargetVisibleWithinScrollArea(
+      horizontal,
       '[data-testid="scroll-area-lane-last"]',
-    );
-    if (!(lastLane instanceof HTMLElement)) {
-      return null;
-    }
+    ),
+  ).toBe(true);
 
-    const nodeRect = node.getBoundingClientRect();
-    const laneRect = lastLane.getBoundingClientRect();
-
-    return {
-      canScroll: node.scrollWidth > node.clientWidth,
-      overflowX: styles.overflowX,
-      overflowY: styles.overflowY,
-      scrollLeft: node.scrollLeft,
-      lastLaneVisible:
-        laneRect.left >= nodeRect.left && laneRect.right <= nodeRect.right,
-    };
+  await both.evaluate((node) => {
+    node.scrollTo({
+      top: node.scrollHeight,
+      left: node.scrollWidth,
+    });
   });
 
-  expect(horizontalMetrics).not.toBeNull();
-  expect(horizontalMetrics?.canScroll).toBe(true);
-  expect(horizontalMetrics?.overflowX).toBe("auto");
-  expect(horizontalMetrics?.overflowY).toBe("hidden");
-  expect(horizontalMetrics?.scrollLeft ?? 0).toBeGreaterThan(0);
-  expect(horizontalMetrics?.lastLaneVisible).toBe(true);
+  const bothState = await readScrollbarState(both);
+  expect(bothState.scrollTop).toBeGreaterThan(0);
+  expect(bothState.scrollLeft).toBeGreaterThan(0);
+  expect(
+    await isTargetVisibleWithinScrollArea(
+      both,
+      '[data-testid="scroll-area-board-card-last"]',
+    ),
+  ).toBe(true);
+});
+
+test("scroll area thumbs support pointer dragging", async ({ page }) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("scroll-area-section");
+  const vertical = section.getByTestId("scroll-area-vertical");
+  const horizontal = section.getByTestId("scroll-area-horizontal");
+  const verticalRoot = vertical.locator("xpath=..");
+  const horizontalRoot = horizontal.locator("xpath=..");
+
+  expect(await dragThumb(verticalRoot, "vertical", 72)).toBe(true);
+
+  await expect
+    .poll(async () => {
+      const state = await readScrollbarState(vertical);
+      return state.scrollTop;
+    })
+    .toBeGreaterThan(0);
+
+  expect(await dragThumb(horizontalRoot, "horizontal", 96)).toBe(true);
+
+  await expect
+    .poll(async () => {
+      const state = await readScrollbarState(horizontal);
+      return state.scrollLeft;
+    })
+    .toBeGreaterThan(0);
 });

--- a/packages/react/tests/scroll-area.spec.ts
+++ b/packages/react/tests/scroll-area.spec.ts
@@ -2,6 +2,8 @@ import { type Locator, expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
+type Axis = "vertical" | "horizontal";
+
 async function readScrollbarState(locator: Locator) {
   return locator.evaluate((node) => {
     const styles = window.getComputedStyle(node);
@@ -27,6 +29,55 @@ async function readScrollbarState(locator: Locator) {
   });
 }
 
+async function readScrollbarChrome(scrollAreaRoot: Locator, axis: Axis) {
+  return scrollAreaRoot.evaluate((node, currentAxis) => {
+    const track = node.querySelector(`[data-scrollbar-track="${currentAxis}"]`);
+    const thumb = node.querySelector(`[data-scrollbar-thumb="${currentAxis}"]`);
+    if (!(track instanceof HTMLElement) || !(thumb instanceof HTMLElement)) {
+      return null;
+    }
+
+    const trackStyles = window.getComputedStyle(track);
+    const thumbStyles = window.getComputedStyle(thumb);
+
+    return {
+      thumbBackgroundColor: thumbStyles.backgroundColor,
+      trackBackgroundColor: trackStyles.backgroundColor,
+      trackBackgroundImage: trackStyles.backgroundImage,
+      trackOpacity: Number.parseFloat(trackStyles.opacity),
+    };
+  }, axis);
+}
+
+function isTransparentColor(color: string) {
+  return color === "rgba(0, 0, 0, 0)" || color === "transparent";
+}
+
+async function expectScrollbarChromeVisible(
+  scrollAreaRoot: Locator,
+  axis: Axis,
+) {
+  await expect
+    .poll(
+      async () =>
+        (await readScrollbarChrome(scrollAreaRoot, axis))?.trackOpacity ?? -1,
+    )
+    .toBeGreaterThan(0.8);
+}
+
+async function expectScrollbarChromeHidden(
+  scrollAreaRoot: Locator,
+  axis: Axis,
+) {
+  await expect
+    .poll(
+      async () =>
+        (await readScrollbarChrome(scrollAreaRoot, axis))?.trackOpacity ?? 1,
+      { timeout: 2_000 },
+    )
+    .toBeLessThan(0.1);
+}
+
 async function isTargetVisibleWithinScrollArea(
   scrollArea: Locator,
   selector: string,
@@ -49,10 +100,7 @@ async function isTargetVisibleWithinScrollArea(
   }, selector);
 }
 
-async function readThumbTravel(
-  scrollAreaRoot: Locator,
-  axis: "vertical" | "horizontal",
-) {
+async function readThumbTravel(scrollAreaRoot: Locator, axis: Axis) {
   return scrollAreaRoot.evaluate((node, currentAxis) => {
     const track = node.querySelector(`[data-scrollbar-track="${currentAxis}"]`);
     const thumb = node.querySelector(`[data-scrollbar-thumb="${currentAxis}"]`);
@@ -69,11 +117,7 @@ async function readThumbTravel(
   }, axis);
 }
 
-async function dragThumb(
-  scrollAreaRoot: Locator,
-  axis: "vertical" | "horizontal",
-  delta: number,
-) {
+async function dragThumb(scrollAreaRoot: Locator, axis: Axis, delta: number) {
   return scrollAreaRoot.evaluate(
     (node, { currentAxis, currentDelta }) => {
       const thumb = node.querySelector(
@@ -131,7 +175,7 @@ async function dragThumb(
   );
 }
 
-test("scroll area hides native scrollbars and keeps custom chrome in sync", async ({
+test("scroll area renders thumb-only chrome and keeps it in sync", async ({
   page,
   browserName,
 }) => {
@@ -182,12 +226,50 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
     '[data-scrollbar-track="horizontal"]',
   );
 
-  await expect(verticalTrack).toBeVisible();
-  await expect(verticalThumb).toBeVisible();
-  await expect(horizontalTrack).toBeVisible();
-  await expect(horizontalThumb).toBeVisible();
-  await expect(bothVerticalTrack).toBeVisible();
-  await expect(bothHorizontalTrack).toBeVisible();
+  await expect(verticalTrack).toHaveCount(1);
+  await expect(verticalThumb).toHaveCount(1);
+  await expect(horizontalTrack).toHaveCount(1);
+  await expect(horizontalThumb).toHaveCount(1);
+  await expect(bothVerticalTrack).toHaveCount(1);
+  await expect(bothHorizontalTrack).toHaveCount(1);
+
+  const verticalChrome = await readScrollbarChrome(verticalRoot, "vertical");
+  const horizontalChrome = await readScrollbarChrome(
+    horizontalRoot,
+    "horizontal",
+  );
+  const bothVerticalChrome = await readScrollbarChrome(bothRoot, "vertical");
+  const bothHorizontalChrome = await readScrollbarChrome(
+    bothRoot,
+    "horizontal",
+  );
+
+  expect(verticalChrome).not.toBeNull();
+  expect(horizontalChrome).not.toBeNull();
+  expect(bothVerticalChrome).not.toBeNull();
+  expect(bothHorizontalChrome).not.toBeNull();
+  expect(isTransparentColor(verticalChrome?.trackBackgroundColor ?? "")).toBe(
+    true,
+  );
+  expect(isTransparentColor(horizontalChrome?.trackBackgroundColor ?? "")).toBe(
+    true,
+  );
+  expect(
+    isTransparentColor(bothVerticalChrome?.trackBackgroundColor ?? ""),
+  ).toBe(true);
+  expect(
+    isTransparentColor(bothHorizontalChrome?.trackBackgroundColor ?? ""),
+  ).toBe(true);
+  expect(verticalChrome?.trackBackgroundImage).toBe("none");
+  expect(horizontalChrome?.trackBackgroundImage).toBe("none");
+  expect(bothVerticalChrome?.trackBackgroundImage).toBe("none");
+  expect(bothHorizontalChrome?.trackBackgroundImage).toBe("none");
+  expect(isTransparentColor(verticalChrome?.thumbBackgroundColor ?? "")).toBe(
+    false,
+  );
+  expect(isTransparentColor(horizontalChrome?.thumbBackgroundColor ?? "")).toBe(
+    false,
+  );
 
   const verticalState = await readScrollbarState(vertical);
   expect(verticalState.overflowX).toBe("hidden");
@@ -228,6 +310,15 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
   expect(initialVerticalThumbTravel).not.toBeNull();
   expect(initialHorizontalThumbTravel).not.toBeNull();
 
+  await vertical.hover();
+  await expectScrollbarChromeVisible(verticalRoot, "vertical");
+  await horizontal.hover();
+  await expectScrollbarChromeVisible(horizontalRoot, "horizontal");
+  await expectScrollbarChromeHidden(verticalRoot, "vertical");
+  await expectScrollbarChromeHidden(horizontalRoot, "horizontal");
+
+  await vertical.hover();
+  await expectScrollbarChromeVisible(verticalRoot, "vertical");
   await vertical.press("PageDown");
 
   await expect
@@ -245,8 +336,10 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
   expect(
     (nextVerticalThumbTravel ?? 0) - (initialVerticalThumbTravel ?? 0),
   ).toBeGreaterThan(0);
+  await expectScrollbarChromeVisible(verticalRoot, "vertical");
 
   await horizontal.hover();
+  await expectScrollbarChromeVisible(horizontalRoot, "horizontal");
   await page.mouse.wheel(4000, 0);
 
   await expect
@@ -265,6 +358,7 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
     (nextHorizontalThumbTravel ?? 0) - (initialHorizontalThumbTravel ?? 0),
   ).toBeGreaterThan(0);
 
+  await both.hover();
   await both.evaluate((node) => {
     node.scrollTo({
       top: node.scrollHeight,
@@ -275,6 +369,8 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
   const bothState = await readScrollbarState(both);
   expect(bothState.scrollTop).toBeGreaterThan(0);
   expect(bothState.scrollLeft).toBeGreaterThan(0);
+  await expectScrollbarChromeVisible(bothRoot, "vertical");
+  await expectScrollbarChromeVisible(bothRoot, "horizontal");
   expect(
     await isTargetVisibleWithinScrollArea(
       both,
@@ -283,7 +379,9 @@ test("scroll area hides native scrollbars and keeps custom chrome in sync", asyn
   ).toBe(true);
 });
 
-test("scroll area thumbs support pointer dragging", async ({ page }) => {
+test("scroll area thumbs support pointer dragging after idle fade", async ({
+  page,
+}) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("scroll-area-section");
@@ -292,6 +390,11 @@ test("scroll area thumbs support pointer dragging", async ({ page }) => {
   const verticalRoot = vertical.locator("xpath=..");
   const horizontalRoot = horizontal.locator("xpath=..");
 
+  await expectScrollbarChromeHidden(verticalRoot, "vertical");
+  await expectScrollbarChromeHidden(horizontalRoot, "horizontal");
+
+  await vertical.hover();
+  await expectScrollbarChromeVisible(verticalRoot, "vertical");
   expect(await dragThumb(verticalRoot, "vertical", 72)).toBe(true);
 
   await expect
@@ -301,6 +404,8 @@ test("scroll area thumbs support pointer dragging", async ({ page }) => {
     })
     .toBeGreaterThan(0);
 
+  await horizontal.hover();
+  await expectScrollbarChromeVisible(horizontalRoot, "horizontal");
   expect(await dragThumb(horizontalRoot, "horizontal", 96)).toBe(true);
 
   await expect

--- a/registry.json
+++ b/registry.json
@@ -141,7 +141,7 @@
     "scroll-area": {
       "type": "file",
       "name": "ScrollArea.tsx",
-      "checksum": "c6679c517f65fe38b4ab0dcbf64d94d55d43d6e70e3551aaaea9a67d1f6a025e"
+      "checksum": "9f851451b79dea919dd35a8e035de17e4ca6d64cd8daf53fe8f2a2c2fdc901ae"
     },
     "select": {
       "type": "file",

--- a/registry.json
+++ b/registry.json
@@ -53,7 +53,7 @@
     "avatar": {
       "type": "file",
       "name": "Avatar.tsx",
-      "checksum": "d870900d76cbe766baf1068f640339b25ec3ab323df7b8c296d2dbb618dc38ce"
+      "checksum": "7bfd63ba237f9365bc58c3b1e222f26df6a775f4c1de57d3579b14608797dc1d"
     },
     "badge": {
       "type": "file",

--- a/registry.json
+++ b/registry.json
@@ -141,7 +141,7 @@
     "scroll-area": {
       "type": "file",
       "name": "ScrollArea.tsx",
-      "checksum": "2869883734755c875ad09e504d28f53b39aee9063bdac84e613e68e6fc121467"
+      "checksum": "c6679c517f65fe38b4ab0dcbf64d94d55d43d6e70e3551aaaea9a67d1f6a025e"
     },
     "select": {
       "type": "file",

--- a/registry.json
+++ b/registry.json
@@ -141,7 +141,7 @@
     "scroll-area": {
       "type": "file",
       "name": "ScrollArea.tsx",
-      "checksum": "9f851451b79dea919dd35a8e035de17e4ca6d64cd8daf53fe8f2a2c2fdc901ae"
+      "checksum": "0c4a080d853ce07ee024251af10c823aa79a79676d31bb4949d59a941e0111c0"
     },
     "select": {
       "type": "file",


### PR DESCRIPTION
## Summary
- replace native ScrollArea chrome with synced custom overlay scrollbar tracks and thumbs
- support vertical, horizontal, and both-axis overflow with pointer dragging and resize/scroll metric syncing
- expand the harness and Playwright coverage for hidden native scrollbars, bidirectional overflow, and thumb dragging

## Testing
- bun run react:test:e2e -- tests/scroll-area.spec.ts --project=chromium
- bun run react:build
- bun run registry:checksums

@p-sw please review.