### PR TITLE
feat: add FileInput component

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
 - Component Implementation
   - [ ] DateTimeInput
   - [x] Input
-  - [ ] FileInput
+  - [x] FileInput
   - [ ] ImageInput
   - [x] Form
   - [x] Textarea

--- a/packages/react/components/FileInput.tsx
+++ b/packages/react/components/FileInput.tsx
@@ -1,0 +1,91 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const fileInputColors = {
+  background: {
+    default: "bg-neutral-50 dark:bg-neutral-900",
+    hover: "hover:bg-neutral-100 dark:hover:bg-neutral-800",
+    invalid: "invalid:bg-red-100 dark:invalid:bg-red-900",
+    invalidHover: "hover:invalid:bg-red-200 dark:hover:invalid:bg-red-800",
+  },
+  border: {
+    default: "border-neutral-400 dark:border-neutral-600",
+    invalid: "invalid:border-red-400 dark:invalid:border-red-600",
+  },
+  ring: {
+    default: "ring-transparent focus-within:ring-current",
+    invalid:
+      "invalid:focus-within:ring-red-400 dark:invalid:focus-within:ring-red-600",
+  },
+  file: {
+    default:
+      "file:bg-neutral-200 dark:file:bg-neutral-800 file:text-neutral-950 dark:file:text-neutral-50",
+    hover: "hover:file:bg-neutral-300 dark:hover:file:bg-neutral-700",
+  },
+};
+
+const [fileInputVariant, resolveFileInputVariantProps] = vcn({
+  base: `block rounded-md border p-1.5 text-sm ring-1 outline-hidden transition-all duration-200 file:mr-3 file:cursor-pointer file:rounded-sm file:border-0 file:px-3 file:py-1.5 file:text-sm file:font-medium disabled:cursor-not-allowed disabled:brightness-50 disabled:saturate-0 disabled:file:cursor-not-allowed ${fileInputColors.background.default} ${fileInputColors.background.hover} ${fileInputColors.background.invalid} ${fileInputColors.background.invalidHover} ${fileInputColors.border.default} ${fileInputColors.border.invalid} ${fileInputColors.ring.default} ${fileInputColors.ring.invalid} ${fileInputColors.file.default} ${fileInputColors.file.hover}`,
+  variants: {
+    unstyled: {
+      true: "border-none bg-transparent p-0 ring-0 hover:bg-transparent invalid:hover:bg-transparent invalid:focus-within:bg-transparent invalid:focus-within:ring-0 file:mr-0 file:rounded-none file:bg-transparent file:px-0 file:py-0 hover:file:bg-transparent",
+      false: "",
+    },
+    full: {
+      true: "w-full",
+      false: "w-fit",
+    },
+  },
+  defaults: {
+    unstyled: false,
+    full: false,
+  },
+});
+
+interface FileInputProps
+  extends VariantProps<typeof fileInputVariant>,
+    Omit<React.ComponentPropsWithoutRef<"input">, "type"> {
+  invalid?: string;
+}
+
+const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveFileInputVariantProps(props);
+    const {
+      invalid,
+      "aria-invalid": ariaInvalid,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const isInvalid = Boolean(invalid);
+    const resolvedAriaInvalid = isInvalid ? true : ariaInvalid;
+
+    const innerRef = React.useRef<HTMLInputElement | null>(null);
+
+    React.useEffect(() => {
+      if (innerRef.current) {
+        innerRef.current.setCustomValidity(invalid ?? "");
+      }
+    }, [invalid]);
+
+    return (
+      <input
+        type="file"
+        aria-invalid={resolvedAriaInvalid}
+        ref={(el) => {
+          innerRef.current = el;
+          if (typeof ref === "function") {
+            ref(el);
+          } else if (ref) {
+            ref.current = el;
+          }
+        }}
+        className={fileInputVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+FileInput.displayName = "FileInput";
+
+export { FileInput };

--- a/packages/react/tests/file-input.spec.ts
+++ b/packages/react/tests/file-input.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("file input accepts native file selection and clears custom validity", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("file-input-section");
+  const input = section.getByLabel("Project assets");
+  const selection = section.getByTestId("file-input-selection");
+
+  await expect(input).toHaveAttribute("aria-invalid", "true");
+  await expect(selection).toHaveText("No files selected");
+
+  const beforeSelection = await input.evaluate((element) => {
+    const target = element as HTMLInputElement;
+    return {
+      customError: target.validity.customError,
+      message: target.validationMessage,
+      valid: target.validity.valid,
+    };
+  });
+
+  expect(beforeSelection.customError).toBe(true);
+  expect(beforeSelection.valid).toBe(false);
+  expect(beforeSelection.message).toContain("Select at least one file");
+
+  await input.setInputFiles([
+    {
+      name: "brief.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("Brief"),
+    },
+    {
+      name: "hero.png",
+      mimeType: "image/png",
+      buffer: Buffer.from("Hero"),
+    },
+  ]);
+
+  await expect(selection).toHaveText("brief.pdf, hero.png");
+  await expect(input).not.toHaveAttribute("aria-invalid", "true");
+
+  const afterSelection = await input.evaluate((element) => {
+    const target = element as HTMLInputElement;
+    return {
+      files: Array.from(target.files ?? []).map((file) => file.name),
+      valid: target.validity.valid,
+    };
+  });
+
+  expect(afterSelection.files).toEqual(["brief.pdf", "hero.png"]);
+  expect(afterSelection.valid).toBe(true);
+});

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -48,6 +48,7 @@ import {
   DrawerRoot,
   DrawerTrigger,
 } from "../../components/Drawer";
+import { FileInput } from "../../components/FileInput";
 import {
   FormError,
   FormHelper,
@@ -467,6 +468,50 @@ const FormShowcase = () => {
           </FormHelper>
           <FormError />
         </FormItem>
+      </div>
+    </Section>
+  );
+};
+
+const FileInputShowcase = () => {
+  const [selectedFiles, setSelectedFiles] = React.useState<string[]>([]);
+  const invalid =
+    selectedFiles.length === 0 ? "Select at least one file" : undefined;
+
+  return (
+    <Section
+      testId="file-input"
+      title="FileInput"
+      description="Native file selection with custom validity that clears after upload."
+    >
+      <div className="flex w-full max-w-md flex-col gap-3">
+        <Label htmlFor="roadmap-file-input">
+          <span>Project assets</span>
+          <FileInput
+            id="roadmap-file-input"
+            aria-describedby="file-input-selection"
+            accept=".pdf,.png"
+            full
+            invalid={invalid}
+            multiple
+            onChange={(event) => {
+              setSelectedFiles(
+                Array.from(event.currentTarget.files ?? []).map(
+                  (file) => file.name,
+                ),
+              );
+            }}
+          />
+        </Label>
+        <output
+          id="file-input-selection"
+          data-testid="file-input-selection"
+          className="text-sm opacity-70"
+        >
+          {selectedFiles.length > 0
+            ? selectedFiles.join(", ")
+            : "No files selected"}
+        </output>
       </div>
     </Section>
   );
@@ -1203,6 +1248,7 @@ const showcases = [
   DialogShowcase,
   DrawerShowcase,
   FormShowcase,
+  FileInputShowcase,
   InputShowcase,
   TextareaShowcase,
   LabelShowcase,

--- a/registry.json
+++ b/registry.json
@@ -103,6 +103,11 @@
       "name": "Drawer.tsx",
       "checksum": "610c6287f8166c7684c184867808e8c78d795765be3ea460bda8eb7f03408c73"
     },
+    "file-input": {
+      "type": "file",
+      "name": "FileInput.tsx",
+      "checksum": "03a4d341612a3534a0f0f022c41d2af37a32fcd03cfc86b6f6a5bdd0e221aaec"
+    },
     "form": {
       "type": "file",
       "name": "Form.tsx",


### PR DESCRIPTION
## Summary
- add a native-first `FileInput` component with simple invalid-state handling and full-width option
- add a focused Playwright harness showcase and `file-input.spec.ts` coverage for native file selection
- register `FileInput` in `registry.json` and mark the roadmap item complete in `README.md`

## Validation
- bun run react:test:e2e -- tests/file-input.spec.ts --project=chromium
- bun run react:build
- bun --filter react lint components/FileInput.tsx tests/harness/App.tsx tests/file-input.spec.ts
- bun run registry:checksums

## Screenshot
![FileInput screenshot](https://public.psw.kr/pswui-file-input-pr-53.png)

cc @p-sw