### PR TITLE
fix(drawer): preserve mobile scroll gestures

### DIFF
--- a/packages/react/components/Drawer.tsx
+++ b/packages/react/components/Drawer.tsx
@@ -127,6 +127,61 @@ const DRAWER_INITIAL_FOCUS_SELECTOR = [
   "textarea:not([disabled])",
   '[tabindex]:not([tabindex="-1"]):not([disabled])',
 ].join(", ");
+const DRAWER_TOUCH_DRAG_INTENT_OFFSET = 8;
+
+type DrawerPosition = "top" | "bottom" | "left" | "right";
+
+function isVerticalDrawer(position: DrawerPosition) {
+  return ["top", "bottom"].includes(position);
+}
+
+function isScrollableOverflow(overflow: string) {
+  return ["auto", "overlay", "scroll"].includes(overflow);
+}
+
+function canScrollableAncestorConsumeTouchGesture(
+  target: EventTarget | null,
+  container: HTMLElement,
+  position: DrawerPosition,
+  movement: number,
+) {
+  const vertical = isVerticalDrawer(position);
+  let current = target instanceof Element ? target : null;
+
+  while (current && container.contains(current)) {
+    if (current instanceof HTMLElement) {
+      const computedStyle = window.getComputedStyle(current);
+      const axisOverflow = vertical
+        ? computedStyle.overflowY
+        : computedStyle.overflowX;
+      const scrollSize = vertical
+        ? current.scrollHeight - current.clientHeight
+        : current.scrollWidth - current.clientWidth;
+
+      if (
+        scrollSize > 0 &&
+        (isScrollableOverflow(axisOverflow) ||
+          isScrollableOverflow(computedStyle.overflow))
+      ) {
+        const currentScroll = vertical ? current.scrollTop : current.scrollLeft;
+        if (movement > 0 ? currentScroll > 0 : currentScroll < scrollSize) {
+          return true;
+        }
+      }
+    }
+
+    if (current === container) {
+      break;
+    }
+    current = current.parentElement;
+  }
+
+  return false;
+}
+
+function isCloseGesture(position: DrawerPosition, movement: number) {
+  return ["top", "left"].includes(position) ? movement < 0 : movement > 0;
+}
 
 interface DrawerOverlayProps
   extends Omit<VariantProps<typeof drawerOverlayVariant>, "opened">,
@@ -303,6 +358,18 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
     const Comp = asChild ? Slot : "div";
 
     const internalRef = useRef<HTMLDivElement | null>(null);
+    const isDraggingRef = useRef(false);
+    const dragDeltaRef = useRef(0);
+    const dragTouchRef = useRef({ x: 0, y: 0 });
+    const touchGestureRef = useRef<{
+      mode: "idle" | "pending" | "dragging" | "scrolling";
+      startTouch: { x: number; y: number };
+      target: EventTarget | null;
+    }>({
+      mode: "idle",
+      startTouch: { x: 0, y: 0 },
+      target: null,
+    });
 
     function onEscapeKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
       if (event.key !== "Escape" || event.defaultPrevented) return;
@@ -328,6 +395,9 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
     }, [state.isRendered]);
 
     function onMouseDown() {
+      isDraggingRef.current = true;
+      dragDeltaRef.current = 0;
+      dragTouchRef.current = { x: 0, y: 0 };
       setState((prev) => ({ ...prev, isDragging: true }));
       setDragState({
         isDragging: true,
@@ -337,42 +407,40 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
     }
 
     function onTouchStart(e: ReactTouchEvent<HTMLDivElement>) {
-      setState((prev) => ({ ...prev, isDragging: true }));
-      setDragState({
-        isDragging: true,
-        delta: 0,
-        prevTouch: { x: e.touches[0].pageX, y: e.touches[0].pageY },
-      });
+      touchGestureRef.current = {
+        mode: "pending",
+        startTouch: { x: e.touches[0].pageX, y: e.touches[0].pageY },
+        target: e.target,
+      };
     }
 
     useEffect(() => {
-      function onMouseUp(e: TouchEvent): void;
-      function onMouseUp(e: MouseEvent): void;
-      function onMouseUp(e: TouchEvent | MouseEvent) {
-        if (
-          e.target instanceof Element &&
-          internalRef.current &&
-          internalRef.current.contains(e.target)
-        ) {
-          const size = ["top", "bottom"].includes(position)
-            ? e.target.getBoundingClientRect().height
-            : e.target.getBoundingClientRect().width;
+      function onMouseUp(_: TouchEvent): void;
+      function onMouseUp(_: MouseEvent): void;
+      function onMouseUp(_e: TouchEvent | MouseEvent) {
+        if (isDraggingRef.current && internalRef.current) {
+          const size = isVerticalDrawer(position)
+            ? internalRef.current.getBoundingClientRect().height
+            : internalRef.current.getBoundingClientRect().width;
           setState((prev) => ({
             ...prev,
             isDragging: false,
             opened:
-              Math.abs(dragState.delta) > state.closeThreshold * size
+              Math.abs(dragDeltaRef.current) > state.closeThreshold * size
                 ? false
                 : prev.opened,
             movePercentage: 0,
           }));
-        } else {
-          setState((prev) => ({
-            ...prev,
-            isDragging: false,
-            movePercentage: 0,
-          }));
         }
+
+        isDraggingRef.current = false;
+        dragDeltaRef.current = 0;
+        dragTouchRef.current = { x: 0, y: 0 };
+        touchGestureRef.current = {
+          mode: "idle",
+          startTouch: { x: 0, y: 0 },
+          target: null,
+        };
         setDragState({
           isDragging: false,
           delta: 0,
@@ -383,43 +451,128 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
       function onMouseMove(e: TouchEvent): void;
       function onMouseMove(e: MouseEvent): void;
       function onMouseMove(e: MouseEvent | TouchEvent) {
-        if (dragState.isDragging) {
-          setDragState((prev) => {
-            let movement = ["top", "bottom"].includes(position)
-              ? "movementY" in e
-                ? e.movementY
-                : e.touches[0].pageY - prev.prevTouch.y
-              : "movementX" in e
-                ? e.movementX
-                : e.touches[0].pageX - prev.prevTouch.x;
+        if ("touches" in e) {
+          const currentTouch = { x: e.touches[0].pageX, y: e.touches[0].pageY };
+          const touchGesture = touchGestureRef.current;
+
+          if (touchGesture.mode === "pending") {
+            const primaryMovement = isVerticalDrawer(position)
+              ? currentTouch.y - touchGesture.startTouch.y
+              : currentTouch.x - touchGesture.startTouch.x;
+            const secondaryMovement = isVerticalDrawer(position)
+              ? currentTouch.x - touchGesture.startTouch.x
+              : currentTouch.y - touchGesture.startTouch.y;
+
             if (
-              (["top", "left"].includes(position) &&
-                dragState.delta >= 0 &&
-                movement > 0) ||
-              (["bottom", "right"].includes(position) &&
-                dragState.delta <= 0 &&
-                movement < 0)
+              Math.abs(secondaryMovement) >= DRAWER_TOUCH_DRAG_INTENT_OFFSET &&
+              Math.abs(secondaryMovement) > Math.abs(primaryMovement)
             ) {
-              movement =
-                movement /
-                Math.abs(dragState.delta === 0 ? 1 : dragState.delta);
+              touchGestureRef.current = { ...touchGesture, mode: "scrolling" };
+              return;
             }
-            return {
-              ...prev,
-              delta: prev.delta + movement,
-              ...("touches" in e
-                ? {
-                    prevTouch: { x: e.touches[0].pageX, y: e.touches[0].pageY },
-                  }
-                : {}),
-            };
-          });
+
+            if (Math.abs(primaryMovement) < DRAWER_TOUCH_DRAG_INTENT_OFFSET) {
+              return;
+            }
+
+            if (
+              !internalRef.current ||
+              !isCloseGesture(position, primaryMovement) ||
+              canScrollableAncestorConsumeTouchGesture(
+                touchGesture.target,
+                internalRef.current,
+                position,
+                primaryMovement,
+              )
+            ) {
+              touchGestureRef.current = { ...touchGesture, mode: "scrolling" };
+              return;
+            }
+
+            touchGestureRef.current = { ...touchGesture, mode: "dragging" };
+            isDraggingRef.current = true;
+            dragDeltaRef.current = primaryMovement;
+            dragTouchRef.current = currentTouch;
+
+            if (internalRef.current) {
+              const size = isVerticalDrawer(position)
+                ? internalRef.current.getBoundingClientRect().height
+                : internalRef.current.getBoundingClientRect().width;
+              const movePercentage = primaryMovement / size;
+              setState((prev) => ({
+                ...prev,
+                isDragging: true,
+                movePercentage: ["top", "left"].includes(position)
+                  ? -movePercentage
+                  : movePercentage,
+              }));
+            }
+
+            setDragState({
+              isDragging: true,
+              delta: primaryMovement,
+              prevTouch: currentTouch,
+            });
+
+            if (e.cancelable) {
+              e.preventDefault();
+            }
+
+            return;
+          }
+
+          if (touchGesture.mode !== "dragging" || !isDraggingRef.current) {
+            return;
+          }
+
+          if (e.cancelable) {
+            e.preventDefault();
+          }
+        }
+
+        if (isDraggingRef.current) {
+          const currentTouch =
+            "touches" in e
+              ? { x: e.touches[0].pageX, y: e.touches[0].pageY }
+              : null;
+          let movement = isVerticalDrawer(position)
+            ? "movementY" in e
+              ? e.movementY
+              : (currentTouch?.y ?? 0) - dragTouchRef.current.y
+            : "movementX" in e
+              ? e.movementX
+              : (currentTouch?.x ?? 0) - dragTouchRef.current.x;
+
+          if (
+            (["top", "left"].includes(position) &&
+              dragDeltaRef.current >= 0 &&
+              movement > 0) ||
+            (["bottom", "right"].includes(position) &&
+              dragDeltaRef.current <= 0 &&
+              movement < 0)
+          ) {
+            movement =
+              movement /
+              Math.abs(dragDeltaRef.current === 0 ? 1 : dragDeltaRef.current);
+          }
+
+          const nextDelta = dragDeltaRef.current + movement;
+          dragDeltaRef.current = nextDelta;
+          if (currentTouch) {
+            dragTouchRef.current = currentTouch;
+          }
+
+          setDragState((prev) => ({
+            ...prev,
+            delta: nextDelta,
+            ...(currentTouch ? { prevTouch: currentTouch } : {}),
+          }));
 
           if (internalRef.current) {
-            const size = ["top", "bottom"].includes(position)
+            const size = isVerticalDrawer(position)
               ? internalRef.current.getBoundingClientRect().height
               : internalRef.current.getBoundingClientRect().width;
-            const movePercentage = dragState.delta / size;
+            const movePercentage = nextDelta / size;
             setState((prev) => ({
               ...prev,
               movePercentage: ["top", "left"].includes(position)
@@ -432,7 +585,7 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
 
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("mouseup", onMouseUp);
-      window.addEventListener("touchmove", onMouseMove);
+      window.addEventListener("touchmove", onMouseMove, { passive: false });
       window.addEventListener("touchend", onMouseUp);
       return () => {
         window.removeEventListener("mousemove", onMouseMove);
@@ -440,7 +593,7 @@ const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
         window.removeEventListener("touchmove", onMouseMove);
         window.removeEventListener("touchend", onMouseUp);
       };
-    }, [state, setState, dragState, position]);
+    }, [position, setState, state.closeThreshold]);
 
     return (
       <div

--- a/packages/react/tests/drawer.spec.ts
+++ b/packages/react/tests/drawer.spec.ts
@@ -1,6 +1,82 @@
-import { expect, test } from "@playwright/test";
+import { type Locator, expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
+
+async function dispatchSyntheticTouchEvent(
+  locator: Locator,
+  type: "touchend" | "touchmove" | "touchstart",
+  point: { x: number; y: number },
+) {
+  await locator.evaluate(
+    (element, { type, point }) => {
+      const touchInit = {
+        clientX: point.x,
+        clientY: point.y,
+        identifier: 0,
+        pageX: point.x,
+        pageY: point.y,
+        screenX: point.x,
+        screenY: point.y,
+        target: element,
+      };
+      const createTouch = () =>
+        (() => {
+          try {
+            if (typeof Touch === "function") {
+              return new Touch(touchInit);
+            }
+          } catch {}
+
+          return touchInit;
+        })();
+      const touches = type === "touchend" ? [] : [createTouch()];
+      const changedTouches = [createTouch()];
+
+      let event: Event;
+      try {
+        event =
+          typeof TouchEvent === "function"
+            ? new TouchEvent(type, {
+                bubbles: true,
+                cancelable: true,
+                changedTouches,
+                targetTouches: touches,
+                touches,
+              })
+            : new Event(type, {
+                bubbles: true,
+                cancelable: true,
+              });
+      } catch {
+        event = new Event(type, {
+          bubbles: true,
+          cancelable: true,
+        });
+      }
+
+      if (!("touches" in event)) {
+        Object.defineProperties(event, {
+          changedTouches: {
+            configurable: true,
+            value: changedTouches,
+          },
+          targetTouches: {
+            configurable: true,
+            value: touches,
+          },
+          touches: {
+            configurable: true,
+            value: touches,
+          },
+        });
+      }
+
+      const dispatchTarget = type === "touchstart" ? element : window;
+      dispatchTarget.dispatchEvent(event);
+    },
+    { type, point },
+  );
+}
 
 test("drawer exposes dialog semantics and moves focus inside on open", async ({
   page,
@@ -45,4 +121,125 @@ test("drawer closes on Escape", async ({ page }) => {
   await closeButton.focus();
   await closeButton.press("Escape");
   await expect(closeButton).not.toBeVisible();
+});
+
+test.describe("drawer touch interactions", () => {
+  test.use({
+    hasTouch: true,
+    viewport: { width: 390, height: 844 },
+  });
+
+  test.beforeEach(async ({ browserName }) => {
+    test.skip(
+      browserName === "firefox",
+      "Firefox does not support the touch emulation used by this regression.",
+    );
+  });
+
+  test("nested scrollable content does not start a close drag while it can still scroll", async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+
+    const section = page.getByTestId("drawer-scroll-section");
+    await section
+      .getByRole("button", { name: "Open scrollable drawer" })
+      .click({ force: true });
+
+    const dialog = page.getByRole("dialog", {
+      name: "Scrollable drawer title",
+    });
+    const scrollRegion = dialog.getByTestId("drawer-scroll-region");
+
+    await dialog.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await scrollRegion.evaluate((element) => {
+      element.scrollTop = 80;
+    });
+
+    const box = await scrollRegion.boundingBox();
+    if (!box) {
+      throw new Error("Expected drawer scroll region to have a bounding box");
+    }
+
+    const x = box.x + box.width / 2;
+    const startY = box.y + box.height / 2;
+
+    await dispatchSyntheticTouchEvent(scrollRegion, "touchstart", {
+      x,
+      y: startY,
+    });
+    await dispatchSyntheticTouchEvent(scrollRegion, "touchmove", {
+      x,
+      y: startY + 140,
+    });
+
+    expect(
+      await dialog.evaluate(
+        (element) => (element as HTMLElement).style.transform,
+      ),
+    ).toBe("");
+
+    await dispatchSyntheticTouchEvent(scrollRegion, "touchend", {
+      x,
+      y: startY + 140,
+    });
+
+    await expect(dialog).toBeVisible();
+  });
+
+  test("drawer starts a close drag with a downward swipe once nested content is already at the top", async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+
+    const section = page.getByTestId("drawer-scroll-section");
+    await section
+      .getByRole("button", { name: "Open scrollable drawer" })
+      .click({ force: true });
+
+    const dialog = page.getByRole("dialog", {
+      name: "Scrollable drawer title",
+    });
+    const scrollRegion = dialog.getByTestId("drawer-scroll-region");
+
+    await dialog.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await scrollRegion.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+
+    const box = await scrollRegion.boundingBox();
+    if (!box) {
+      throw new Error("Expected drawer scroll region to have a bounding box");
+    }
+
+    const x = box.x + box.width / 2;
+    const startY = box.y + 48;
+    const swipeDistance = await dialog.evaluate(
+      (element) => element.getBoundingClientRect().height * 0.75,
+    );
+
+    await dispatchSyntheticTouchEvent(scrollRegion, "touchstart", {
+      x,
+      y: startY,
+    });
+    await dispatchSyntheticTouchEvent(scrollRegion, "touchmove", {
+      x,
+      y: startY + swipeDistance,
+    });
+
+    await expect
+      .poll(() =>
+        dialog.evaluate((element) => (element as HTMLElement).style.transform),
+      )
+      .toContain("translateY");
+
+    await dispatchSyntheticTouchEvent(scrollRegion, "touchend", {
+      x,
+      y: startY + swipeDistance,
+    });
+  });
 });

--- a/packages/react/tests/drawer.spec.ts
+++ b/packages/react/tests/drawer.spec.ts
@@ -1,4 +1,4 @@
-import { type Locator, expect, test } from "@playwright/test";
+import { type Locator, type Page, expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
@@ -78,6 +78,28 @@ async function dispatchSyntheticTouchEvent(
   );
 }
 
+async function openScrollableDrawer(page: Page) {
+  const section = page.getByTestId("drawer-scroll-section");
+  await section
+    .getByRole("button", { name: "Open scrollable drawer" })
+    .click({ force: true });
+
+  const dialog = page.getByRole("dialog", {
+    name: "Scrollable drawer title",
+  });
+  const closeButton = dialog.getByRole("button", {
+    name: "Close scrollable drawer",
+  });
+
+  await expect(dialog).toBeVisible();
+  await expect(closeButton).toBeFocused();
+
+  return {
+    dialog,
+    scrollRegion: dialog.getByTestId("drawer-scroll-region"),
+  };
+}
+
 test("drawer exposes dialog semantics and moves focus inside on open", async ({
   page,
 }) => {
@@ -141,15 +163,7 @@ test.describe("drawer touch interactions", () => {
   }) => {
     await gotoHarness(page);
 
-    const section = page.getByTestId("drawer-scroll-section");
-    await section
-      .getByRole("button", { name: "Open scrollable drawer" })
-      .click({ force: true });
-
-    const dialog = page.getByRole("dialog", {
-      name: "Scrollable drawer title",
-    });
-    const scrollRegion = dialog.getByTestId("drawer-scroll-region");
+    const { dialog, scrollRegion } = await openScrollableDrawer(page);
 
     await dialog.evaluate((element) => {
       element.scrollTop = 0;
@@ -194,15 +208,7 @@ test.describe("drawer touch interactions", () => {
   }) => {
     await gotoHarness(page);
 
-    const section = page.getByTestId("drawer-scroll-section");
-    await section
-      .getByRole("button", { name: "Open scrollable drawer" })
-      .click({ force: true });
-
-    const dialog = page.getByRole("dialog", {
-      name: "Scrollable drawer title",
-    });
-    const scrollRegion = dialog.getByTestId("drawer-scroll-region");
+    const { dialog, scrollRegion } = await openScrollableDrawer(page);
 
     await dialog.evaluate((element) => {
       element.scrollTop = 0;

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -438,6 +438,67 @@ const DrawerShowcase = () => {
   );
 };
 
+const drawerScrollItems = Array.from({ length: 24 }, (_, index) => index + 1);
+
+const DrawerScrollShowcase = () => {
+  return (
+    <Section
+      testId="drawer-scroll"
+      title="Drawer Mobile Scroll"
+      description="Scrollable content should not trigger a close swipe until it reaches the edge."
+    >
+      <DrawerRoot closeThreshold={0.1}>
+        <DrawerTrigger>
+          <Button>Open scrollable drawer</Button>
+        </DrawerTrigger>
+        <DrawerOverlay>
+          <DrawerContent
+            position="bottom"
+            className="max-h-96"
+            aria-labelledby="drawer-scroll-title"
+            aria-describedby="drawer-scroll-description"
+          >
+            <DrawerHeader>
+              <h3
+                id="drawer-scroll-title"
+                className="text-lg font-semibold"
+              >
+                Scrollable drawer title
+              </h3>
+            </DrawerHeader>
+            <DrawerBody>
+              <p id="drawer-scroll-description">
+                Use touch scrolling in the nested region before swiping down to
+                close.
+              </p>
+              <div
+                data-testid="drawer-scroll-region"
+                className="mt-4 max-h-48 overflow-y-auto rounded-lg border border-neutral-200 p-3 dark:border-neutral-800"
+              >
+                <div className="flex flex-col gap-3">
+                  {drawerScrollItems.map((item) => (
+                    <p
+                      key={item}
+                      className="text-sm"
+                    >
+                      Scroll item {item}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            </DrawerBody>
+            <DrawerFooter>
+              <DrawerClose>
+                <Button>Close scrollable drawer</Button>
+              </DrawerClose>
+            </DrawerFooter>
+          </DrawerContent>
+        </DrawerOverlay>
+      </DrawerRoot>
+    </Section>
+  );
+};
+
 const FormShowcase = () => {
   return (
     <Section
@@ -1289,6 +1350,7 @@ const showcases = [
   CheckboxShowcase,
   DialogShowcase,
   DrawerShowcase,
+  DrawerScrollShowcase,
   FormShowcase,
   FileInputShowcase,
   InputShowcase,

--- a/registry.json
+++ b/registry.json
@@ -101,7 +101,7 @@
     "drawer": {
       "type": "file",
       "name": "Drawer.tsx",
-      "checksum": "610c6287f8166c7684c184867808e8c78d795765be3ea460bda8eb7f03408c73"
+      "checksum": "39b70074bb3940340734e9438e4fbb7a7c22902fd3933e4bce313c2b9bb5152e"
     },
     "file-input": {
       "type": "file",


### PR DESCRIPTION
## Summary
- preserve native scrolling inside nested scrollable regions before Drawer swipe-to-close takes over on touch devices
- delay drag start until the gesture clearly matches the Drawer close axis, and use refs for fast touch release handling
- add a dedicated mobile regression harness, touch e2e coverage, and refresh registry checksums

## Validation
- bun run react:test:e2e -- tests/drawer.spec.ts --project=chromium --project=firefox --project=webkit
- cd packages/react && bun run lint -- components/Drawer.tsx tests/drawer.spec.ts tests/harness/App.tsx
- bun run react:build
- bun run registry:checksums

cc @p-sw