### PR TITLE
fix(card): link card semantics to title and description

### DIFF
--- a/packages/react/components/Card.tsx
+++ b/packages/react/components/Card.tsx
@@ -1,6 +1,36 @@
 import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
 import React from "react";
 
+function mergeAriaIds(...values: Array<string | undefined>) {
+  const ids = new Set<string>();
+
+  for (const value of values) {
+    if (!value) continue;
+
+    for (const token of value.split(/\s+/)) {
+      if (token) ids.add(token);
+    }
+  }
+
+  return ids.size > 0 ? Array.from(ids).join(" ") : undefined;
+}
+
+function resolveSlottedId(children: React.ReactNode) {
+  if (!React.isValidElement(children)) return undefined;
+
+  const { id } = children.props as { id?: unknown };
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+interface CardContextValue {
+  titleId?: string;
+  descriptionId?: string;
+  registerTitle: (id: string) => () => void;
+  registerDescription: (id: string) => () => void;
+}
+
+const CardContext = React.createContext<CardContextValue | null>(null);
+
 const [cardVariant, resolveCardVariantProps] = vcn({
   base: "flex flex-col gap-4 rounded-lg border border-neutral-200 bg-white p-6 text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-black dark:text-neutral-50",
   variants: {},
@@ -13,17 +43,51 @@ interface CardProps
     AsChild {}
 
 const Card = React.forwardRef<HTMLElement, CardProps>((props, ref) => {
+  const [titleId, setTitleId] = React.useState<string>();
+  const [descriptionId, setDescriptionId] = React.useState<string>();
+  const registerTitle = React.useRef((id: string) => {
+    setTitleId(id);
+
+    return () => {
+      setTitleId((currentId) => (currentId === id ? undefined : currentId));
+    };
+  }).current;
+  const registerDescription = React.useRef((id: string) => {
+    setDescriptionId(id);
+
+    return () => {
+      setDescriptionId((currentId) =>
+        currentId === id ? undefined : currentId,
+      );
+    };
+  }).current;
   const [variantProps, otherPropsCompressed] = resolveCardVariantProps(props);
-  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+  const {
+    asChild,
+    "aria-describedby": ariaDescribedBy,
+    "aria-labelledby": ariaLabelledBy,
+    ...otherPropsExtracted
+  } = otherPropsCompressed;
 
   const Comp = asChild ? Slot : "article";
 
   return (
-    <Comp
-      ref={ref}
-      className={cardVariant(variantProps)}
-      {...otherPropsExtracted}
-    />
+    <CardContext.Provider
+      value={{
+        titleId,
+        descriptionId,
+        registerTitle,
+        registerDescription,
+      }}
+    >
+      <Comp
+        ref={ref}
+        className={cardVariant(variantProps)}
+        aria-labelledby={mergeAriaIds(ariaLabelledBy, titleId)}
+        aria-describedby={mergeAriaIds(ariaDescribedBy, descriptionId)}
+        {...otherPropsExtracted}
+      />
+    </CardContext.Provider>
   );
 });
 Card.displayName = "Card";
@@ -71,15 +135,29 @@ interface CardTitleProps
 
 const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
   (props, ref) => {
+    const cardContext = React.useContext(CardContext);
+    const generatedId = React.useId();
     const [variantProps, otherPropsCompressed] =
       resolveCardTitleVariantProps(props);
-    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+    const { asChild, id, ...otherPropsExtracted } = otherPropsCompressed;
+    const registerTitle = cardContext?.registerTitle;
+    const resolvedId =
+      id ??
+      (asChild ? resolveSlottedId(otherPropsExtracted.children) : undefined) ??
+      (cardContext ? generatedId : undefined);
 
     const Comp = asChild ? Slot : "h3";
+
+    React.useEffect(() => {
+      if (!registerTitle || !resolvedId) return undefined;
+
+      return registerTitle(resolvedId);
+    }, [registerTitle, resolvedId]);
 
     return (
       <Comp
         ref={ref}
+        id={resolvedId}
         className={cardTitleVariant(variantProps)}
         {...otherPropsExtracted}
       />
@@ -103,15 +181,29 @@ const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   CardDescriptionProps
 >((props, ref) => {
+  const cardContext = React.useContext(CardContext);
+  const generatedId = React.useId();
   const [variantProps, otherPropsCompressed] =
     resolveCardDescriptionVariantProps(props);
-  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+  const { asChild, id, ...otherPropsExtracted } = otherPropsCompressed;
+  const registerDescription = cardContext?.registerDescription;
+  const resolvedId =
+    id ??
+    (asChild ? resolveSlottedId(otherPropsExtracted.children) : undefined) ??
+    (cardContext ? generatedId : undefined);
 
   const Comp = asChild ? Slot : "p";
+
+  React.useEffect(() => {
+    if (!registerDescription || !resolvedId) return undefined;
+
+    return registerDescription(resolvedId);
+  }, [registerDescription, resolvedId]);
 
   return (
     <Comp
       ref={ref}
+      id={resolvedId}
       className={cardDescriptionVariant(variantProps)}
       {...otherPropsExtracted}
     />

--- a/packages/react/tests/card.spec.ts
+++ b/packages/react/tests/card.spec.ts
@@ -2,23 +2,25 @@ import { expect, test } from "@playwright/test";
 
 import { gotoHarness } from "./helpers";
 
-test("card renders semantic sections and content", async ({ page }) => {
+test("card wires its title and description to the article", async ({
+  page,
+}) => {
   await gotoHarness(page);
 
   const section = page.getByTestId("card-section");
   const card = section.getByTestId("card-root");
+  const title = card.getByRole("heading", { level: 3, name: "Design review" });
+  const description = card.getByText("Ready for a focused component pass.");
 
   await expect(card).toHaveJSProperty("tagName", "ARTICLE");
   await expect(card.getByTestId("card-header")).toHaveJSProperty(
     "tagName",
     "HEADER",
   );
-  await expect(
-    card.getByRole("heading", { level: 3, name: "Design review" }),
-  ).toBeVisible();
-  await expect(
-    card.getByText("Ready for a focused component pass."),
-  ).toHaveJSProperty("tagName", "P");
+  await expect(title).toBeVisible();
+  await expect(description).toHaveJSProperty("tagName", "P");
+  await expect(title).toHaveAttribute("id", /.+/);
+  await expect(description).toHaveAttribute("id", /.+/);
   await expect(card.getByTestId("card-content")).toContainText(
     "Review spacing, contrast, and responsive structure.",
   );
@@ -27,4 +29,37 @@ test("card renders semantic sections and content", async ({ page }) => {
     "FOOTER",
   );
   await expect(card.getByRole("button", { name: "Open review" })).toBeVisible();
+  const titleId = await title.getAttribute("id");
+  const descriptionId = await description.getAttribute("id");
+
+  expect(titleId).toBeTruthy();
+  expect(descriptionId).toBeTruthy();
+
+  if (!titleId || !descriptionId) {
+    throw new Error("Card title and description must render stable ids.");
+  }
+
+  await expect(card).toHaveAttribute("aria-labelledby", titleId);
+  await expect(card).toHaveAttribute("aria-describedby", descriptionId);
+});
+
+test("card preserves aria wiring when root and text use asChild", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const card = page.getByTestId("card-as-child-root");
+
+  await expect(card).toHaveJSProperty("tagName", "SECTION");
+  await expect(
+    card.getByRole("heading", { level: 4, name: "Linked review" }),
+  ).toHaveAttribute("id", "card-as-child-title");
+  await expect(
+    card.getByText("Custom elements still label the card."),
+  ).toHaveAttribute("id", "card-as-child-description");
+  await expect(card).toHaveAttribute("aria-labelledby", "card-as-child-title");
+  await expect(card).toHaveAttribute(
+    "aria-describedby",
+    "card-as-child-description",
+  );
 });

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -329,18 +329,43 @@ const CardShowcase = () => {
       title="Card"
       description="Static content grouped with header, body, and footer."
     >
-      <Card data-testid="card-root">
-        <CardHeader data-testid="card-header">
-          <CardTitle>Design review</CardTitle>
-          <CardDescription>Ready for a focused component pass.</CardDescription>
-        </CardHeader>
-        <CardContent data-testid="card-content">
-          <p>Review spacing, contrast, and responsive structure.</p>
-        </CardContent>
-        <CardFooter data-testid="card-footer">
-          <Button>Open review</Button>
-        </CardFooter>
-      </Card>
+      <div className="flex flex-col gap-4">
+        <Card data-testid="card-root">
+          <CardHeader data-testid="card-header">
+            <CardTitle>Design review</CardTitle>
+            <CardDescription>
+              Ready for a focused component pass.
+            </CardDescription>
+          </CardHeader>
+          <CardContent data-testid="card-content">
+            <p>Review spacing, contrast, and responsive structure.</p>
+          </CardContent>
+          <CardFooter data-testid="card-footer">
+            <Button>Open review</Button>
+          </CardFooter>
+        </Card>
+
+        <Card
+          asChild
+          data-testid="card-as-child-root"
+        >
+          <section>
+            <CardHeader>
+              <CardTitle asChild>
+                <h4 id="card-as-child-title">Linked review</h4>
+              </CardTitle>
+              <CardDescription asChild>
+                <div id="card-as-child-description">
+                  Custom elements still label the card.
+                </div>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p>Slot-based composition keeps the same accessible wiring.</p>
+            </CardContent>
+          </section>
+        </Card>
+      </div>
     </Section>
   );
 };

--- a/registry.json
+++ b/registry.json
@@ -73,7 +73,7 @@
     "card": {
       "type": "file",
       "name": "Card.tsx",
-      "checksum": "eceab4a86dd98dd42681587cc217972e3d1f8eb5e45f1203b969f430d1f6a9ac"
+      "checksum": "35c3d51a0db14815aa675808d794025fcf9af8eea18932df6f3d2a602cc8b7b7"
     },
     "checkbox": {
       "type": "file",


### PR DESCRIPTION
## Summary
- link `Card` roots to their `CardTitle` and `CardDescription` with generated or slotted ids
- preserve caller-provided ids and `asChild` composition while merging any existing aria labelling props
- extend the Card Playwright coverage for default and `asChild` labelling flows

## Testing
- bun run react:test:e2e -- tests/card.spec.ts --project=chromium
- bun run react:build

@p-sw