### PR TITLE
fix: unblock mobile drawer scrolling

### DIFF
--- a/packages/react/components/Drawer.tsx
+++ b/packages/react/components/Drawer.tsx
@@ -108,7 +108,7 @@ const [drawerOverlayVariant, resolveDrawerOverlayVariantProps] = vcn({
   base: "fixed inset-0 transition-[backdrop-filter] duration-75",
   variants: {
     opened: {
-      true: "pointer-events-auto select-auto touch-none", // touch-none to prevent outside scrolling
+      true: "pointer-events-auto select-auto",
       false: "pointer-events-none select-none",
     },
   },
@@ -224,6 +224,21 @@ const DrawerOverlay = forwardRef<HTMLDivElement, DrawerOverlayProps>(
         document.removeEventListener("keydown", onKeyDown);
       };
     }, [document, state.opened, setState]);
+
+    useEffect(() => {
+      const overlay = internalRef.current;
+      if (!overlay || !state.opened || !isMounted) return;
+
+      function onTouchMove(event: TouchEvent) {
+        if (event.target !== overlay || !event.cancelable) return;
+        event.preventDefault();
+      }
+
+      overlay.addEventListener("touchmove", onTouchMove, { passive: false });
+      return () => {
+        overlay.removeEventListener("touchmove", onTouchMove);
+      };
+    }, [isMounted, state.opened]);
 
     const Comp = asChild ? Slot : "div";
     const backdropFilter = `brightness(${

--- a/packages/react/tests/drawer.spec.ts
+++ b/packages/react/tests/drawer.spec.ts
@@ -203,6 +203,37 @@ test.describe("drawer touch interactions", () => {
     await expect(dialog).toBeVisible();
   });
 
+  test("overlay keeps drawer touch scrolling enabled while cancelling scrim touch moves", async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+
+    const { dialog } = await openScrollableDrawer(page);
+
+    const overlayState = await dialog.evaluate((element) => {
+      const overlay = element.parentElement?.parentElement;
+      if (!(overlay instanceof HTMLElement)) {
+        throw new Error("Expected drawer overlay to wrap the dialog");
+      }
+
+      const event = new Event("touchmove", {
+        bubbles: true,
+        cancelable: true,
+      });
+
+      overlay.dispatchEvent(event);
+
+      return {
+        defaultPrevented: event.defaultPrevented,
+        overlayTouchAction: window.getComputedStyle(overlay).touchAction,
+      };
+    });
+
+    expect(overlayState.overlayTouchAction).not.toBe("none");
+    expect(overlayState.defaultPrevented).toBe(true);
+    await expect(dialog).toBeVisible();
+  });
+
   test("drawer starts a close drag with a downward swipe once nested content is already at the top", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- remove the overlay-wide `touch-none` rule that blocked native touch scrolling inside Drawer content
- only cancel `touchmove` events when the scrim itself is touched, preserving page scroll lock without breaking inner scrolling
- add a focused regression test that checks the overlay keeps scrolling enabled while scrim touch moves are still cancelled

## Verification
- `cd packages/react && bunx playwright test tests/drawer.spec.ts --project=chromium`
- `cd packages/react && bunx playwright test tests/drawer.spec.ts --project=webkit`
- `cd packages/react && bun run lint components/Drawer.tsx tests/drawer.spec.ts`
- `cd packages/react && bun run build`

@p-sw please review.