### PR TITLE
chore(registry): refresh drawer checksum

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -101,7 +101,7 @@
     "drawer": {
       "type": "file",
       "name": "Drawer.tsx",
-      "checksum": "39b70074bb3940340734e9438e4fbb7a7c22902fd3933e4bce313c2b9bb5152e"
+      "checksum": "ab1ade1734b5ba4317ab90e9fc8993d5688dafd0a14f76b100e167c0aff63fc8"
     },
     "file-input": {
       "type": "file",


### PR DESCRIPTION
## Summary
- refresh the Drawer registry checksum after the merged Drawer implementation change
- keep this PR limited to registry metadata only

## Testing
- bun run registry:checksums

@p-sw