### PR TITLE
feat(react): add datetime input component

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you have any ideas or suggestions, please let me know in [Github Issues](http
 ## Milestones
 
 - Component Implementation
-  - [ ] DateTimeInput
+  - [x] DateTimeInput
   - [x] Input
   - [x] FileInput
   - [ ] ImageInput

--- a/packages/react/components/DateTimeInput.tsx
+++ b/packages/react/components/DateTimeInput.tsx
@@ -1,0 +1,86 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const dateTimeInputColors = {
+  background: {
+    default: "bg-neutral-50 dark:bg-neutral-900",
+    hover: "hover:bg-neutral-100 dark:hover:bg-neutral-800",
+    invalid: "invalid:bg-red-100 dark:invalid:bg-red-900",
+    invalidHover: "hover:invalid:bg-red-200 dark:hover:invalid:bg-red-800",
+  },
+  border: {
+    default: "border-neutral-400 dark:border-neutral-600",
+    invalid: "invalid:border-red-400 dark:invalid:border-red-600",
+  },
+  ring: {
+    default: "ring-transparent focus-within:ring-current",
+    invalid:
+      "invalid:focus-within:ring-red-400 dark:invalid:focus-within:ring-red-600",
+  },
+};
+
+const [dateTimeInputVariant, resolveDateTimeInputVariantProps] = vcn({
+  base: `block rounded-md border p-2 text-sm ring-1 outline-hidden transition-all duration-200 disabled:cursor-not-allowed disabled:brightness-50 disabled:saturate-0 ${dateTimeInputColors.background.default} ${dateTimeInputColors.background.hover} ${dateTimeInputColors.background.invalid} ${dateTimeInputColors.background.invalidHover} ${dateTimeInputColors.border.default} ${dateTimeInputColors.border.invalid} ${dateTimeInputColors.ring.default} ${dateTimeInputColors.ring.invalid}`,
+  variants: {
+    unstyled: {
+      true: "border-none bg-transparent p-0 ring-0 hover:bg-transparent invalid:hover:bg-transparent invalid:focus-within:bg-transparent invalid:focus-within:ring-0",
+      false: "",
+    },
+    full: {
+      true: "w-full",
+      false: "w-fit",
+    },
+  },
+  defaults: {
+    unstyled: false,
+    full: false,
+  },
+});
+
+interface DateTimeInputProps
+  extends VariantProps<typeof dateTimeInputVariant>,
+    Omit<React.ComponentPropsWithoutRef<"input">, "type"> {
+  invalid?: string;
+}
+
+const DateTimeInput = React.forwardRef<HTMLInputElement, DateTimeInputProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveDateTimeInputVariantProps(props);
+    const {
+      invalid,
+      "aria-invalid": ariaInvalid,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const isInvalid = Boolean(invalid);
+    const resolvedAriaInvalid = isInvalid ? true : ariaInvalid;
+
+    const innerRef = React.useRef<HTMLInputElement | null>(null);
+
+    React.useEffect(() => {
+      if (innerRef.current) {
+        innerRef.current.setCustomValidity(invalid ?? "");
+      }
+    }, [invalid]);
+
+    return (
+      <input
+        type="datetime-local"
+        aria-invalid={resolvedAriaInvalid}
+        ref={(el) => {
+          innerRef.current = el;
+          if (typeof ref === "function") {
+            ref(el);
+          } else if (ref) {
+            ref.current = el;
+          }
+        }}
+        className={dateTimeInputVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+DateTimeInput.displayName = "DateTimeInput";
+
+export { DateTimeInput };

--- a/packages/react/tests/datetime-input.spec.ts
+++ b/packages/react/tests/datetime-input.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoHarness } from "./helpers";
+
+test("datetime input uses native datetime-local behavior and clears custom validity", async ({
+  page,
+}) => {
+  await gotoHarness(page);
+
+  const section = page.getByTestId("datetime-input-section");
+  const input = section.getByLabel("Launch window");
+  const value = section.getByTestId("datetime-input-value");
+
+  await expect(input).toHaveAttribute("type", "datetime-local");
+  await expect(input).toHaveAttribute("aria-invalid", "true");
+  await expect(value).toHaveText("No launch window selected");
+
+  const beforeSelection = await input.evaluate((element) => {
+    const target = element as HTMLInputElement;
+    return {
+      customError: target.validity.customError,
+      message: target.validationMessage,
+      valid: target.validity.valid,
+    };
+  });
+
+  expect(beforeSelection.customError).toBe(true);
+  expect(beforeSelection.valid).toBe(false);
+  expect(beforeSelection.message).toContain("Choose a launch date and time");
+
+  await input.fill("2026-05-20T14:30");
+
+  await expect(value).toHaveText("2026-05-20T14:30");
+  await expect(input).not.toHaveAttribute("aria-invalid", "true");
+
+  const afterSelection = await input.evaluate((element) => {
+    const target = element as HTMLInputElement;
+    return {
+      customError: target.validity.customError,
+      type: target.type,
+      valid: target.validity.valid,
+      value: target.value,
+    };
+  });
+
+  expect(afterSelection.customError).toBe(false);
+  expect(afterSelection.type).toBe("datetime-local");
+  expect(afterSelection.valid).toBe(true);
+  expect(afterSelection.value).toBe("2026-05-20T14:30");
+});

--- a/packages/react/tests/harness/App.tsx
+++ b/packages/react/tests/harness/App.tsx
@@ -27,6 +27,7 @@ import {
   CardTitle,
 } from "../../components/Card";
 import { Checkbox } from "../../components/Checkbox";
+import { DateTimeInput } from "../../components/DateTimeInput";
 import {
   DialogClose,
   DialogContent,
@@ -512,6 +513,42 @@ const FileInputShowcase = () => {
           {selectedFiles.length > 0
             ? selectedFiles.join(", ")
             : "No files selected"}
+        </output>
+      </div>
+    </Section>
+  );
+};
+
+const DateTimeInputShowcase = () => {
+  const [value, setValue] = React.useState("");
+  const invalid = value ? undefined : "Choose a launch date and time";
+
+  return (
+    <Section
+      testId="datetime-input"
+      title="DateTimeInput"
+      description="Native date and time selection with custom validity."
+    >
+      <div className="flex w-full max-w-md flex-col gap-3">
+        <Label htmlFor="roadmap-datetime-input">
+          <span>Launch window</span>
+          <DateTimeInput
+            id="roadmap-datetime-input"
+            aria-describedby="datetime-input-value"
+            full
+            invalid={invalid}
+            min="2026-01-01T00:00"
+            step={60}
+            value={value}
+            onChange={(event) => setValue(event.currentTarget.value)}
+          />
+        </Label>
+        <output
+          id="datetime-input-value"
+          data-testid="datetime-input-value"
+          className="text-sm opacity-70"
+        >
+          {value || "No launch window selected"}
         </output>
       </div>
     </Section>
@@ -1290,6 +1327,7 @@ const showcases = [
   DialogShowcase,
   DrawerShowcase,
   FormShowcase,
+  DateTimeInputShowcase,
   FileInputShowcase,
   InputShowcase,
   TextareaShowcase,

--- a/registry.json
+++ b/registry.json
@@ -103,6 +103,11 @@
       "name": "Drawer.tsx",
       "checksum": "ab1ade1734b5ba4317ab90e9fc8993d5688dafd0a14f76b100e167c0aff63fc8"
     },
+    "datetime-input": {
+      "type": "file",
+      "name": "DateTimeInput.tsx",
+      "checksum": "2c3ab912faaac5eec059035d72d27d0bb2a1bc5a1ac92a554d5224cf3dd89af1"
+    },
     "file-input": {
       "type": "file",
       "name": "FileInput.tsx",


### PR DESCRIPTION
## Summary
- add a native-first `DateTimeInput` component based on the existing input styling conventions
- add a harness showcase and focused Playwright coverage for custom validity behavior
- update the roadmap and registry entry for the new component

## Testing
- bun run registry:checksums
- cd packages/react && bun run lint components/DateTimeInput.tsx tests/harness/App.tsx tests/datetime-input.spec.ts
- bun run react:build
- cd packages/react && NODE_PATH=/home/developer/.openclaw/workspace-devin/ui/packages/react/node_modules bunx playwright test tests/datetime-input.spec.ts --config /tmp/datetime-input-playwright.config.ts

## Preview
![DateTimeInput preview](https://public.psw.kr/pswui-datetime-input-pr-59.png)

@p-sw